### PR TITLE
AMQNET-585: NMS AMQP .NetStd 2.0 Client Support

### DIFF
--- a/HelloWorld/HelloWorld.csproj
+++ b/HelloWorld/HelloWorld.csproj
@@ -25,8 +25,7 @@ under the License.
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>HelloWorld</RootNamespace>
     <AssemblyName>HelloWorld</AssemblyName>
-    <!--<TargetFrameworks>netcoreapp2.0;net46</TargetFrameworks>-->
-    <TargetFrameworks>net46</TargetFrameworks>
+    <TargetFrameworks>net462;netcoreapp2.2</TargetFrameworks>
     
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
@@ -79,23 +78,7 @@ under the License.
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  
-  <ItemGroup Condition="'$(TargetFramework)'=='net452'">
-    <!--
-    <Reference Include="Amqp.Net, Version=1.2.0.0, Culture=neutral, PublicKeyToken=905a7b1e6458e0c3, processorArchitecture=MSIL">
-      <HintPath>..\..\..\nuget\packages\AMQPNetLite.1.2.2\lib\net45\Amqp.Net.dll</HintPath>
-      <Private>True</Private>
-    </Reference> -->
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
-  </ItemGroup>
+  </PropertyGroup>  
   <ItemGroup>
     <EmbeddedResource Remove="Backup\**" />
     <EmbeddedResource Remove="NMS.AMQP\**" />
@@ -115,23 +98,6 @@ under the License.
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <BootstrapperPackage Include=".NETFramework,Version=v4.5.2">
-      <Visible>False</Visible>
-      <ProductName>Microsoft .NET Framework 4.5.2 %28x86 and x64%29</ProductName>
-      <Install>true</Install>
-    </BootstrapperPackage>
-    <BootstrapperPackage Include=".NETFramework,Version=v4.7">
-      <Visible>False</Visible>
-      <ProductName>Microsoft .NET Framework 4.7 %28x86 and x64%29</ProductName>
-      <Install>true</Install>
-    </BootstrapperPackage>
-    <BootstrapperPackage Include="Microsoft.Net.Framework.3.5.SP1">
-      <Visible>False</Visible>
-      <ProductName>.NET Framework 3.5 SP1</ProductName>
-      <Install>false</Install>
-    </BootstrapperPackage>
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.2.1" />

--- a/NMS.AMQP/Apache-NMS-AMQP.csproj
+++ b/NMS.AMQP/Apache-NMS-AMQP.csproj
@@ -25,16 +25,31 @@ with the License.  You may obtain a copy of the License at
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Apache.NMS.AMQP</RootNamespace>
     <AssemblyName>Apache.NMS.AMQP</AssemblyName>
-    <!--<TargetFrameworks>netstandard2.0;net35;net40;net46</TargetFrameworks>-->
-    <TargetFrameworks>net452;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <FileAlignment>512</FileAlignment>
     <OutputPath>bin\$(Configuration)\</OutputPath>
+
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <PackageId>Apache.NMS.AMQP</PackageId>
+    <Version>1.0.0</Version>
+    <Authors>Apache ActiveMQ</Authors>
+    <Company>Apache Software Foundation</Company>
+    <Product>Apache ActiveMQ NMS AMQP Client</Product>
+    <Description>Apache ActiveMQ NMS.AMQP provides a NMS based client that uses the AMQP v1.0 protocol.</Description>
+    <Copyright>Copyright (C) 2005-2019 Apache Software Foundation</Copyright>
+    <PackageProjectUrl>https://activemq.apache.org/components/nms/</PackageProjectUrl>
+    <PackageLicense>https://github.com/apache/activemq-nms-amqp/blob/master/NOTICE.txt</PackageLicense>
+    <PackageIconUrl>https://activemq.apache.org/assets/img/activemq_logo_icon.png</PackageIconUrl>
+    <RepositoryUrl>https://github.com/apache/activemq-nms-amqp</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageTags>apache;activemq;nms;amqp;net;messaging</PackageTags>
 
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
@@ -57,20 +72,7 @@ with the License.  You may obtain a copy of the License at
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-    
-  <ItemGroup Condition="'$(TargetFramework)'=='net452'">
-    
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Threading.Tasks" />
-    <!--<Reference Include="System.Net.Http" /> -->
-    <Reference Include="System.Xml" />
-  </ItemGroup>
+  </PropertyGroup>    
     <ItemGroup>
         <Compile Include="../src/main/csharp/**" />
         <Compile Include="Properties\AssemblyInfo.cs" />
@@ -90,35 +92,13 @@ with the License.  You may obtain a copy of the License at
     </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AMQPNetLite" Version="2.1.2" Condition="'$(TargetFramework)'=='net35'" />
-    <PackageReference Include="AMQPNetLite" Version="2.1.2" Condition="'$(TargetFramework)'=='net40'" />
-    <PackageReference Include="AMQPNetLite" Version="2.1.2" Condition="'$(TargetFramework)'=='net46' or '$(TargetFramework)'=='net452'" />
-    <PackageReference Include="AMQPNetLite" Version="2.1.2" Condition="'$(TargetFramework)'=='net47'" />
-    <PackageReference Include="AMQPNetLite.Core" Version="2.1.2" Condition="'$(TargetFramework)'=='netstandard2.0'" />
-    
-    <PackageReference Include="Apache.NMS" Version="1.7.1" />
-    
-
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
-    <PackageReference Include="System.Collections.NonGeneric" Version="4.3.0" />
-    <PackageReference Include="System.Diagnostics.Tools" Version="4.3.0" />
-    <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />
-    <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
-    <PackageReference Include="System.Threading.Timer" Version="4.3.0" />
-
+    <!-- AMQPNetLite.Core is .NET Standard 1.3 package -->
+    <PackageReference Include="AMQPNetLite.Core" Version="2.1.7" />
+    <PackageReference Include="Apache.NMS" Version="1.8.0" />
   </ItemGroup>
   <ItemGroup>
     <None Update="App.config">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-  <!--
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="AMQPNetLite.Core">
-      <Version>2.0.0-rc</Version>
-    </PackageReference>
-  </ItemGroup>
--->  
-  
 </Project>

--- a/StructuredMessage/StructuredMessage.csproj
+++ b/StructuredMessage/StructuredMessage.csproj
@@ -25,8 +25,7 @@ under the License.
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>StructuredMessage</RootNamespace>
     <AssemblyName>StructuredMessage</AssemblyName>
-    <!--<TargetFrameworks>netcoreapp2.0;net46</TargetFrameworks>-->
-    <TargetFrameworks>net46</TargetFrameworks>
+    <TargetFrameworks>net462;netcoreapp2.2</TargetFrameworks>
     
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
@@ -80,22 +79,6 @@ under the License.
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
-  
-  <ItemGroup Condition="'$(TargetFramework)'=='net452'">
-    <!--
-    <Reference Include="Amqp.Net, Version=1.2.0.0, Culture=neutral, PublicKeyToken=905a7b1e6458e0c3, processorArchitecture=MSIL">
-      <HintPath>..\..\..\nuget\packages\AMQPNetLite.1.2.2\lib\net45\Amqp.Net.dll</HintPath>
-      <Private>True</Private>
-    </Reference> -->
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
-  </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Remove="Backup\**" />
     <EmbeddedResource Remove="NMS.AMQP\**" />
@@ -115,23 +98,6 @@ under the License.
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <BootstrapperPackage Include=".NETFramework,Version=v4.5.2">
-      <Visible>False</Visible>
-      <ProductName>Microsoft .NET Framework 4.5.2 %28x86 and x64%29</ProductName>
-      <Install>true</Install>
-    </BootstrapperPackage>
-    <BootstrapperPackage Include=".NETFramework,Version=v4.7">
-      <Visible>False</Visible>
-      <ProductName>Microsoft .NET Framework 4.7 %28x86 and x64%29</ProductName>
-      <Install>true</Install>
-    </BootstrapperPackage>
-    <BootstrapperPackage Include="Microsoft.Net.Framework.3.5.SP1">
-      <Visible>False</Visible>
-      <ProductName>.NET Framework 3.5 SP1</ProductName>
-      <Install>false</Install>
-    </BootstrapperPackage>
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.2.1" />

--- a/src/main/csharp/Connection.cs
+++ b/src/main/csharp/Connection.cs
@@ -436,7 +436,9 @@ namespace Apache.NMS.AMQP
                 }
                 
                 Open openFrame = CreateOpenFrame(this.connInfo);
-                
+
+                this.latch = new CountDownLatch(1);
+
                 Task<Amqp.Connection> fconn = this.implCreate(addr, openFrame, this.OpenResponse);
                 // wait until the Open request is sent
                 this.impl = TaskUtil.Wait(fconn, connInfo.connectTimeout);
@@ -457,7 +459,6 @@ namespace Apache.NMS.AMQP
 
                 this.impl.Closed += OnInternalClosed;
                 this.impl.AddClosedCallback(OnInternalClosed);
-                this.latch = new CountDownLatch(1);
 
                 ConnectionState finishedState = ConnectionState.UNKNOWN;
                 // Wait for Open response 

--- a/src/test/csharp/Test/Util/TestConfig.cs
+++ b/src/test/csharp/Test/Util/TestConfig.cs
@@ -83,7 +83,8 @@ namespace Apache.NMS.AMQP.Test.Util
                 // Load config file path using test parameters.
                 // Should the test parameters not be set load the 
                 // config file with the default name in the current application directory.
-                string configFilePath = NUnit.Framework.TestContext.Parameters.Get(Parameters.TS_PATH) ?? "";
+                string configFilePath = NUnit.Framework.TestContext.Parameters.Get(Parameters.TS_PATH) ?? NUnit.Framework.TestContext.CurrentContext.TestDirectory;
+
                 string configFileName = 
                     NUnit.Framework.TestContext.Parameters.Get(Parameters.TS_FILENAME) ?? Configuration.CONFIG_FILENAME;
                 string filename = null;

--- a/test/Apache-NMS-AMQP-Test.csproj
+++ b/test/Apache-NMS-AMQP-Test.csproj
@@ -17,7 +17,7 @@ under the License.
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net452;net46</TargetFrameworks>
+    <TargetFrameworks>net462;netcoreapp2.2</TargetFrameworks>
 
     <RootNamespace>NMS.AMQP.Test</RootNamespace>
     <AssemblyName>NMS.AMQP.Test</AssemblyName>
@@ -38,6 +38,7 @@ under the License.
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.0" />
     <PackageReference Include="NUnit" Version="3.8.1" />
     <PackageReference Include="NUnit.Console" Version="3.7.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />


### PR DESCRIPTION
- Add .NET Standard support
- Add nuget package configuration
- Update dependencies
- Add Microsoft.NET.Test.Sdk to be able to run tests directly form VS
- Get the directory containing the current test assembly properly
- Fix race condition on .NET Core

In previous implementation, CountDownLatch was instantiated after
OpenResponse subscription was made. It might lead to race conditions
when the connection was established before proper instance CountDownLatch
was set. As a result attempt to call Connect would end up with timeout.
For whatever reasons it wasn't a case with .NET Framework set as
a target framework, but happens every single time when you try to run
tests against .NET Core runtime.