### PR TITLE
AMQNET-595: Set and get group-id message property field

### DIFF
--- a/src/NMS.AMQP/Message/Facade/INmsMessageFacade.cs
+++ b/src/NMS.AMQP/Message/Facade/INmsMessageFacade.cs
@@ -36,6 +36,7 @@ namespace Apache.NMS.AMQP.Message.Facade
         IDestination NMSReplyTo { get; set; }
         DateTime NMSTimestamp { get; set; }
         string NMSType { get; set; }
+        string GroupId { get; set; }
         DateTime Expiration { get; set; }
         sbyte JmsMsgType { get; }
         INmsMessageFacade Copy();

--- a/src/NMS.AMQP/Message/NmsMessage.cs
+++ b/src/NMS.AMQP/Message/NmsMessage.cs
@@ -94,6 +94,12 @@ namespace Apache.NMS.AMQP.Message
             get => Facade.NMSType;
             set => Facade.NMSType = value;
         }
+        
+        public string NMSGroupId
+        {
+            get => Facade.GroupId;
+            set => Facade.GroupId = value;
+        }
 
         public NmsAcknowledgeCallback NmsAcknowledgeCallback { get; set; }
 

--- a/test/Apache-NMS-AMQP-Test/Message/Facade/NmsTestMessageFacade.cs
+++ b/test/Apache-NMS-AMQP-Test/Message/Facade/NmsTestMessageFacade.cs
@@ -73,6 +73,7 @@ namespace NMS.AMQP.Test.Message.Facade
         public IDestination NMSReplyTo { get; set; }
         public DateTime NMSTimestamp { get; set; }
         public string NMSType { get; set; }
+        public string GroupId { get; set; }
         public DateTime Expiration { get; set; }
         public sbyte JmsMsgType { get; }
         public INmsMessageFacade Copy()

--- a/test/Apache-NMS-AMQP-Test/Message/NmsMessageTest.cs
+++ b/test/Apache-NMS-AMQP-Test/Message/NmsMessageTest.cs
@@ -395,6 +395,16 @@ namespace NMS.AMQP.Test.Message
             Assert.Throws<MessageFormatException>(() => msg.Properties.GetFloat(name));
             Assert.Throws<MessageFormatException>(() => msg.Properties.GetDouble(name));
         }
+
+        [Test]
+        public void TestSetAndGetGroupId()
+        {
+            NmsMessage msg = factory.CreateMessage();
+            
+            msg.Properties.SetString("NMSGroupId", "testGroupId");
+            
+            Assert.AreEqual(msg.Facade.GroupId, "testGroupId");
+        }
         
         // TODO: Test conversion for other properties
 


### PR DESCRIPTION
It should be possible to set group-id message property using IMessage interface.