### PR TITLE
AMQNET-595: Set and get group-id message property field

### DIFF
--- a/src/NMS.AMQP/Message/Facade/INmsMessageFacade.cs
+++ b/src/NMS.AMQP/Message/Facade/INmsMessageFacade.cs
@@ -37,6 +37,7 @@ namespace Apache.NMS.AMQP.Message.Facade
         DateTime NMSTimestamp { get; set; }
         string NMSType { get; set; }
         string GroupId { get; set; }
+        uint GroupSequence { get; set; }
         DateTime Expiration { get; set; }
         sbyte JmsMsgType { get; }
         INmsMessageFacade Copy();

--- a/src/NMS.AMQP/Message/NmsMessage.cs
+++ b/src/NMS.AMQP/Message/NmsMessage.cs
@@ -94,11 +94,17 @@ namespace Apache.NMS.AMQP.Message
             get => Facade.NMSType;
             set => Facade.NMSType = value;
         }
-        
-        public string NMSGroupId
+
+        public string NMSXGroupId
         {
             get => Facade.GroupId;
             set => Facade.GroupId = value;
+        }
+
+        public int NMSXGroupSeq
+        {
+            get => (int) Facade.GroupSequence;
+            set => Facade.GroupSequence = (uint) value;
         }
 
         public NmsAcknowledgeCallback NmsAcknowledgeCallback { get; set; }

--- a/test/Apache-NMS-AMQP-Test/Message/Facade/NmsTestMessageFacade.cs
+++ b/test/Apache-NMS-AMQP-Test/Message/Facade/NmsTestMessageFacade.cs
@@ -74,6 +74,7 @@ namespace NMS.AMQP.Test.Message.Facade
         public DateTime NMSTimestamp { get; set; }
         public string NMSType { get; set; }
         public string GroupId { get; set; }
+        public uint GroupSequence { get; set; }
         public DateTime Expiration { get; set; }
         public sbyte JmsMsgType { get; }
         public INmsMessageFacade Copy()

--- a/test/Apache-NMS-AMQP-Test/Message/NmsMessageTest.cs
+++ b/test/Apache-NMS-AMQP-Test/Message/NmsMessageTest.cs
@@ -401,9 +401,19 @@ namespace NMS.AMQP.Test.Message
         {
             NmsMessage msg = factory.CreateMessage();
             
-            msg.Properties.SetString("NMSGroupId", "testGroupId");
+            msg.Properties.SetString("NMSXGroupId", "testGroupId");
             
             Assert.AreEqual(msg.Facade.GroupId, "testGroupId");
+        }
+        
+        [Test]
+        public void TestSetAndGetGroupSequence()
+        {
+            NmsMessage msg = factory.CreateMessage();
+            
+            msg.Properties.SetInt("NMSXGroupSeq", 10);            
+            
+            Assert.AreEqual(msg.Facade.GroupSequence, 10);
         }
         
         // TODO: Test conversion for other properties


### PR DESCRIPTION
This addresses https://github.com/apache/activemq-nms-amqp/pull/12#issuecomment-518114059

Moreover support for GroupSequence was added.