### PR TITLE
AMQNET-597: Remotely closed session is not removed from AmqpConnection

### DIFF
--- a/src/NMS.AMQP/Provider/Amqp/AmqpSession.cs
+++ b/src/NMS.AMQP/Provider/Amqp/AmqpSession.cs
@@ -63,7 +63,10 @@ namespace Apache.NMS.AMQP.Provider.Amqp
                 });
             underlyingSession.AddClosedCallback((sender, error) =>
             {
-                tcs.TrySetException(ExceptionSupport.GetException(error));
+                if (!tcs.TrySetException(ExceptionSupport.GetException(error)))
+                {
+                    Connection.RemoveSession(sessionInfo.Id);
+                }
             });
             return tcs.Task;
         }
@@ -123,7 +126,7 @@ namespace Apache.NMS.AMQP.Provider.Amqp
         {
             consumers.TryRemove(consumerId, out _);
         }
-        
+
         public void RemoveProducer(Id producerId)
         {
             producers.TryRemove(producerId, out _);


### PR DESCRIPTION
The closed callback for sessions does not remove the AmqpSession from the AmqpConnection, unlike AmqpComsumer. Removing the explicit call to close leaves references in the AmqpConnection list for its AmqpSessions.