### PR TITLE
AMQNET-600: Equals and GetHashCode should be overridden for IDestination implementations

### DIFF
--- a/src/NMS.AMQP/NmsQueue.cs
+++ b/src/NMS.AMQP/NmsQueue.cs
@@ -33,5 +33,36 @@ namespace Apache.NMS.AMQP
         public bool IsQueue { get; } = true;
         public bool IsTemporary { get; } = false;
         public string QueueName { get; }
+
+        protected bool Equals(NmsQueue other)
+        {
+            return DestinationType == other.DestinationType && IsTopic == other.IsTopic && IsQueue == other.IsQueue && IsTemporary == other.IsTemporary && QueueName == other.QueueName;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((NmsQueue) obj);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = (int) DestinationType;
+                hashCode = (hashCode * 397) ^ (QueueName != null ? QueueName.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ IsTopic.GetHashCode();
+                hashCode = (hashCode * 397) ^ IsQueue.GetHashCode();
+                hashCode = (hashCode * 397) ^ IsTemporary.GetHashCode();
+                return hashCode;
+            }
+        }
+        
+        public override string ToString()
+        {
+            return $"{nameof(QueueName)}: {QueueName}";
+        }
     }
 }

--- a/src/NMS.AMQP/NmsTemporaryQueue.cs
+++ b/src/NMS.AMQP/NmsTemporaryQueue.cs
@@ -39,5 +39,36 @@ namespace Apache.NMS.AMQP
         {
             Dispose();
         }
+
+        protected bool Equals(NmsTemporaryQueue other)
+        {
+            return QueueName == other.QueueName && DestinationType == other.DestinationType && IsTopic == other.IsTopic && IsQueue == other.IsQueue && IsTemporary == other.IsTemporary;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((NmsTemporaryQueue) obj);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = (int) DestinationType;
+                hashCode = (hashCode * 397) ^ (QueueName != null ? QueueName.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ IsTopic.GetHashCode();
+                hashCode = (hashCode * 397) ^ IsQueue.GetHashCode();
+                hashCode = (hashCode * 397) ^ IsTemporary.GetHashCode();
+                return hashCode;
+            }
+        }
+
+        public override string ToString()
+        {
+            return $"{nameof(QueueName)}: {QueueName}";
+        }
     }
 }

--- a/src/NMS.AMQP/NmsTemporaryTopic.cs
+++ b/src/NMS.AMQP/NmsTemporaryTopic.cs
@@ -35,5 +35,36 @@ namespace Apache.NMS.AMQP
         {
             Dispose();
         }
+
+        protected bool Equals(NmsTemporaryTopic other)
+        {
+            return TopicName == other.TopicName && DestinationType == other.DestinationType && IsTopic == other.IsTopic && IsQueue == other.IsQueue && IsTemporary == other.IsTemporary;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((NmsTemporaryTopic) obj);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = (int) DestinationType;
+                hashCode = (hashCode * 397) ^ (TopicName != null ? TopicName.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ IsTopic.GetHashCode();
+                hashCode = (hashCode * 397) ^ IsQueue.GetHashCode();
+                hashCode = (hashCode * 397) ^ IsTemporary.GetHashCode();
+                return hashCode;
+            }
+        }
+
+        public override string ToString()
+        {
+            return $"{nameof(TopicName)}: {TopicName}";
+        }
     }
 }

--- a/src/NMS.AMQP/NmsTopic.cs
+++ b/src/NMS.AMQP/NmsTopic.cs
@@ -33,5 +33,36 @@ namespace Apache.NMS.AMQP
         public bool IsQueue { get; } = false;
         public bool IsTemporary { get; } = false;
         public string TopicName { get; }
+
+        protected bool Equals(NmsTopic other)
+        {
+            return DestinationType == other.DestinationType && IsTopic == other.IsTopic && IsQueue == other.IsQueue && IsTemporary == other.IsTemporary && TopicName == other.TopicName;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((NmsTopic) obj);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = (int) DestinationType;
+                hashCode = (hashCode * 397) ^ (TopicName != null ? TopicName.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ IsTopic.GetHashCode();
+                hashCode = (hashCode * 397) ^ IsQueue.GetHashCode();
+                hashCode = (hashCode * 397) ^ IsTemporary.GetHashCode();
+                return hashCode;
+            }
+        }
+
+        public override string ToString()
+        {
+            return $"{nameof(TopicName)}: {TopicName}";
+        }
     }
 }

--- a/test/Apache-NMS-AMQP-Test/NmsQueueTest.cs
+++ b/test/Apache-NMS-AMQP-Test/NmsQueueTest.cs
@@ -43,5 +43,26 @@ namespace NMS.AMQP.Test
             NmsQueue queue = new NmsQueue("myQueue");
             Assert.False(queue.IsTemporary, "should not be temporary");
         }
+        
+        [Test]
+        public void TestTwoQueuesWithTheSameNamesAreEqual()
+        {
+            NmsQueue nmsQueue1 = new NmsQueue("myQueue");
+            NmsQueue nmsQueue2 = new NmsQueue("myQueue");
+
+            Assert.AreEqual(nmsQueue1, nmsQueue2);
+            Assert.AreNotSame(nmsQueue1, nmsQueue2);
+            Assert.AreEqual(nmsQueue1.GetHashCode(), nmsQueue2.GetHashCode());
+        }
+        
+        [Test]
+        public void TestTwoQueuesWithDifferentNamesAreNotEqual()
+        {
+            NmsQueue nmsQueue1 = new NmsQueue("myQueue");
+            NmsQueue nmsQueue2 = new NmsQueue("myQueue2");
+
+            Assert.AreNotEqual(nmsQueue1, nmsQueue2);
+            Assert.AreNotEqual(nmsQueue1.GetHashCode(), nmsQueue2.GetHashCode());
+        }
     }
 }

--- a/test/Apache-NMS-AMQP-Test/NmsTemporaryQueueTest.cs
+++ b/test/Apache-NMS-AMQP-Test/NmsTemporaryQueueTest.cs
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Apache.NMS.AMQP;
+using Apache.NMS.AMQP.Util;
+using NUnit.Framework;
+
+namespace NMS.AMQP.Test
+{
+    [TestFixture]
+    public class NmsTemporaryQueueTest
+    {
+        [Test]
+        public void TestTwoTemporaryQueuesWithTheSameAddressesAreEqual()
+        {
+            NmsTemporaryQueue temporaryQueue1 = new NmsTemporaryQueue(new Id("test")) { Address = "myTemporaryQueue" };
+            NmsTemporaryQueue temporaryQueue2 = new NmsTemporaryQueue(new Id("test")) { Address = "myTemporaryQueue" };
+
+            Assert.AreEqual(temporaryQueue1, temporaryQueue2);
+            Assert.AreNotSame(temporaryQueue1, temporaryQueue2);
+            Assert.AreEqual(temporaryQueue1.GetHashCode(), temporaryQueue2.GetHashCode());
+        }
+
+        [Test]
+        public void TestTwoTemporaryQueuesWithDifferentAddressesAreNotEqual()
+        {
+            NmsTemporaryQueue temporaryQueue1 = new NmsTemporaryQueue(new Id("test")) { Address = "myTemporaryQueue" };
+            NmsTemporaryQueue temporaryQueue2 = new NmsTemporaryQueue(new Id("test")) { Address = "myTemporaryQueue2" };
+
+            Assert.AreNotEqual(temporaryQueue1, temporaryQueue2);
+            Assert.AreNotEqual(temporaryQueue1.GetHashCode(), temporaryQueue2.GetHashCode());
+        }
+    }
+}

--- a/test/Apache-NMS-AMQP-Test/NmsTemporaryTopicTest.cs
+++ b/test/Apache-NMS-AMQP-Test/NmsTemporaryTopicTest.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
@@ -16,39 +16,19 @@
  */
 
 using Apache.NMS.AMQP;
+using Apache.NMS.AMQP.Util;
 using NUnit.Framework;
 
 namespace NMS.AMQP.Test
 {
     [TestFixture]
-    public class NmsTopicTest
+    public class NmsTemporaryTopicTest
     {
         [Test]
-        public void TestIsQueue()
+        public void TestTwoTemporaryTopicsWithTheSameAddressesAreEqual()
         {
-            NmsTopic topic = new NmsTopic("myTopic");
-            Assert.False(topic.IsQueue, "should not be a queue");
-        }
-
-        [Test]
-        public void TestIsTopic()
-        {
-            NmsTopic topic = new NmsTopic("myTopic");
-            Assert.True(topic.IsTopic, "should be a topic");
-        }
-
-        [Test]
-        public void TestIsTemporary()
-        {
-            NmsTopic topic = new NmsTopic("myTopic");
-            Assert.False(topic.IsTemporary, "should not be temporary");
-        }
-
-        [Test]
-        public void TestTwoTopicsWithTheSameNamesAreEqual()
-        {
-            NmsTopic nmsTopic1 = new NmsTopic("myTopic");
-            NmsTopic nmsTopic2 = new NmsTopic("myTopic");
+            NmsTemporaryTopic nmsTopic1 = new NmsTemporaryTopic(new Id("test")) { Address = "myTopic" };
+            NmsTemporaryTopic nmsTopic2 = new NmsTemporaryTopic(new Id("test")) { Address = "myTopic" };
 
             Assert.AreEqual(nmsTopic1, nmsTopic2);
             Assert.AreNotSame(nmsTopic1, nmsTopic2);
@@ -56,10 +36,10 @@ namespace NMS.AMQP.Test
         }
         
         [Test]
-        public void TestTwoTopicsWithDifferentNamesNotAreEqual()
+        public void TestTwoTemporaryTopicsWithDifferentAddressesAreNotEqual()
         {
-            NmsTopic nmsTopic1 = new NmsTopic("myTopic");
-            NmsTopic nmsTopic2 = new NmsTopic("myTopic2");
+            NmsTemporaryTopic nmsTopic1 = new NmsTemporaryTopic(new Id("test")) { Address = "myTopic" };
+            NmsTemporaryTopic nmsTopic2 = new NmsTemporaryTopic(new Id("test")) { Address = "myTopic1" };
 
             Assert.AreNotEqual(nmsTopic1, nmsTopic2);
             Assert.AreNotEqual(nmsTopic1.GetHashCode(), nmsTopic2.GetHashCode());


### PR DESCRIPTION
This change is vital if one wants to use NMS AMQP with Spring CachingConnectionFactory, as current implementation prevents it from caching senders and consumers by destination. 