### PR TITLE
AMQNET-602: Set batchable flag to false for amqp transfer

### DIFF
--- a/src/NMS.AMQP/Apache-NMS-AMQP.csproj
+++ b/src/NMS.AMQP/Apache-NMS-AMQP.csproj
@@ -49,8 +49,8 @@ with the License.  You may obtain a copy of the License at
     </PropertyGroup>
 
     <ItemGroup>
-        <None Include="..\..\LICENSE.txt" Pack="true" PackagePath="LICENSE.txt" />
-        <None Include="..\..\NOTICE.txt" Pack="true" PackagePath="NOTICE.txt" />
+        <None Include="..\..\LICENSE.txt" Pack="true" PackagePath="LICENSE.txt"/>
+        <None Include="..\..\NOTICE.txt" Pack="true" PackagePath="NOTICE.txt"/>
     </ItemGroup>
 
     <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/NMS.AMQP/Provider/Amqp/AmqpHandler.cs
+++ b/src/NMS.AMQP/Provider/Amqp/AmqpHandler.cs
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Amqp.Framing;
+using Amqp.Handler;
+
+namespace Apache.NMS.AMQP.Provider.Amqp
+{
+    internal class AmqpHandler : IHandler
+    {
+        private readonly AmqpConnection connection;
+
+        public AmqpHandler(AmqpConnection connection)
+        {
+            this.connection = connection;
+        }
+
+        public bool CanHandle(EventId id)
+        {
+            switch (id)
+            {
+                case EventId.SendDelivery:
+                case EventId.ConnectionRemoteOpen:
+                case EventId.ConnectionLocalOpen:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        public void Handle(Event protocolEvent)
+        {
+            switch (protocolEvent.Id)
+            {
+                case EventId.SendDelivery when protocolEvent.Context is IDelivery delivery:
+                    delivery.Batchable = false;
+                    break;
+                case EventId.ConnectionRemoteOpen when protocolEvent.Context is Open open:
+                    this.connection.OnRemoteOpened(open);
+                    break;
+                case EventId.ConnectionLocalOpen when protocolEvent.Context is Open open:
+                    this.connection.OnLocalOpen(open);
+                    break;
+            }
+        }
+    }
+}

--- a/src/NMS.AMQP/Provider/Amqp/AmqpProducer.cs
+++ b/src/NMS.AMQP/Provider/Amqp/AmqpProducer.cs
@@ -121,13 +121,7 @@ namespace Apache.NMS.AMQP.Provider.Amqp
                     if (envelope.SendAsync)
                         SendAsync(message, transactionalState);
                     else
-                    {
-                        // TODO: Should be unified after https://github.com/Azure/amqpnetlite/pull/374 is sorted out
-                        if (transactionalState != null)
-                            SendSync(message, transactionalState);
-                        else
-                            senderLink.Send(message, TimeSpan.FromMilliseconds(session.Connection.Provider.SendTimeout));
-                    }
+                        SendSync(message, transactionalState);
                 }
                 catch (TimeoutException tex)
                 {

--- a/src/NMS.AMQP/Transport/ITransportContext.cs
+++ b/src/NMS.AMQP/Transport/ITransportContext.cs
@@ -18,6 +18,7 @@
 using System.Threading.Tasks;
 using Amqp;
 using Amqp.Framing;
+using Amqp.Handler;
 
 namespace Apache.NMS.AMQP.Transport
 {
@@ -37,6 +38,6 @@ namespace Apache.NMS.AMQP.Transport
 
         ITransportContext Copy();
 
-        Task<Amqp.Connection> CreateAsync(Address address, Open open = null, OnOpened onOpened = null);
+        Task<Connection> CreateAsync(Address address, IHandler handler);
     }
 }

--- a/src/NMS.AMQP/Transport/SecureTransportContext.cs
+++ b/src/NMS.AMQP/Transport/SecureTransportContext.cs
@@ -24,6 +24,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Amqp;
 using Amqp.Framing;
+using Amqp.Handler;
 using Apache.NMS.AMQP.Util;
 
 namespace Apache.NMS.AMQP.Transport
@@ -228,7 +229,7 @@ namespace Apache.NMS.AMQP.Transport
 
         #region IProviderSecureTransportContext Methods
 
-        public override Task<Amqp.Connection> CreateAsync(Address address, Open open = null, OnOpened onOpened = null)
+        public override Task<Amqp.Connection> CreateAsync(Address address, IHandler handler)
         {
             // Load local certificates
             this.connectionBuilder.SSL.ClientCertificates.AddRange(LoadClientCertificates());
@@ -242,7 +243,7 @@ namespace Apache.NMS.AMQP.Transport
                 throw new NMSSecurityException(string.Format("Invalid SSL Protocol {0} selected from system supported protocols {1}", this.SSLProtocol, PropertyUtil.ToString(SupportedProtocols)));
             }
             
-            return base.CreateAsync(address, open, onOpened);
+            return base.CreateAsync(address, handler);
         }
 
         #endregion

--- a/src/NMS.AMQP/Transport/TransportContext.cs
+++ b/src/NMS.AMQP/Transport/TransportContext.cs
@@ -20,6 +20,8 @@ using System.Net.Sockets;
 using System.Threading.Tasks;
 using Amqp;
 using Amqp.Framing;
+using Amqp.Handler;
+using Apache.NMS.AMQP.Provider.Amqp;
 using Apache.NMS.AMQP.Util;
 
 namespace Apache.NMS.AMQP.Transport
@@ -38,7 +40,7 @@ namespace Apache.NMS.AMQP.Transport
         internal TransportContext()
         {
             connectionBuilder = new Amqp.ConnectionFactory();
-            connectionBuilder.SASL.Profile = Amqp.Sasl.SaslProfile.Anonymous;
+            connectionBuilder.SASL.Profile = Amqp.Sasl.SaslProfile.Anonymous;            
         }
 
         static TransportContext()
@@ -156,9 +158,9 @@ namespace Apache.NMS.AMQP.Transport
             return copy;
         }
 
-        public virtual Task<Amqp.Connection> CreateAsync(Address address, Open open = null, OnOpened onOpened = null)
+        public virtual Task<Connection> CreateAsync(Address address, IHandler handler)
         {
-            return connectionBuilder.CreateAsync(address, open, onOpened);
+            return connectionBuilder.CreateAsync(address, handler);    
         }
 
         protected virtual void CopyInto(TransportContext copy)

--- a/test/Apache-NMS-AMQP-Test/TestAmqp/TestAmqpPeer.cs
+++ b/test/Apache-NMS-AMQP-Test/TestAmqp/TestAmqpPeer.cs
@@ -675,12 +675,14 @@ namespace NMS.AMQP.Test.TestAmqp
             bool sendResponseDisposition,
             DeliveryState responseState,
             bool responseSettled,
-            int dispositionDelay = 0
+            int dispositionDelay = 0,
+            bool batchable = false
         )
         {
             var transferMatcher = new FrameMatcher<Transfer>()
                 .WithAssertion(transfer => Assert.AreEqual(settled, transfer.Settled))
                 .WithAssertion(transfer => stateMatcher(transfer.State))
+                .WithAssertion(transfer => Assert.AreEqual(batchable, transfer.Batchable))
                 .WithAssertion(messageMatcher);
 
             if (sendResponseDisposition)


### PR DESCRIPTION
This PR resolves the performance issue with brokers that respect the batchable flag for amqp transfer. https://github.com/apache/activemq-nms-amqp/pull/8#issuecomment-517366025

It utilizes new Handel API of amqp net lite, and new testing toolkit, and thus we should wait with merge until https://github.com/Azure/amqpnetlite/commit/2c38af646de695c17ccccf6f6992fbeecd2a0252 is released and https://github.com/apache/activemq-nms-amqp/pull/9 is merged. 

Moreover it illustrates the problem pointed out by @cjwmorgan-sol https://github.com/apache/activemq-nms-amqp/pull/9#issuecomment-521632602. **TestSendingMessageNonPersistentSetsBatchableFalse** is failing because of that. I think this issue should be addressed with higher precedence.

Prerequisites:
- [x] amqpnetlite release,
- [x] test toolkit merge
- [x] rebase and history cleanup 