### PR TITLE
AMQNET-607: It should be possible to reset AbsoluteExpiryTime

### DIFF
--- a/src/NMS.AMQP/Message/Facade/INmsMessageFacade.cs
+++ b/src/NMS.AMQP/Message/Facade/INmsMessageFacade.cs
@@ -37,7 +37,7 @@ namespace Apache.NMS.AMQP.Message.Facade
         string NMSType { get; set; }
         string GroupId { get; set; }
         uint GroupSequence { get; set; }
-        DateTime Expiration { get; set; }
+        DateTime? Expiration { get; set; }
         sbyte JmsMsgType { get; }
         
         /// <summary>

--- a/src/NMS.AMQP/Message/NmsMessage.cs
+++ b/src/NMS.AMQP/Message/NmsMessage.cs
@@ -237,8 +237,8 @@ namespace Apache.NMS.AMQP.Message
 
         public bool IsExpired()
         {
-            DateTime expireTime = Facade.Expiration;
-            return expireTime > DateTime.MinValue && DateTime.UtcNow > expireTime;
+            DateTime? expireTime = Facade.Expiration;
+            return expireTime != null && DateTime.UtcNow > expireTime;
         }
 
         public virtual NmsMessage Copy()

--- a/src/NMS.AMQP/NmsSession.cs
+++ b/src/NMS.AMQP/NmsSession.cs
@@ -406,15 +406,12 @@ namespace Apache.NMS.AMQP
             if (isNmsMessage)
                 outbound = (NmsMessage) original;
             else
-            {
                 outbound = NmsMessageTransformation.TransformMessage(Connection.MessageFactory, original);
-            }
 
             if (hasTTL)
                 outbound.Facade.Expiration = timeStamp + timeToLive;
-            // TODO: Reset Expiration when https://github.com/Azure/amqpnetlite/commit/13009980e40aedcb6310f8fa796fbee53be8a389 merged
-            // else
-            //     outbound.Facade.Expiration = DateTime.MinValue;
+            else
+                outbound.Facade.Expiration = null;
 
             outbound.OnSend(timeToLive);
 

--- a/test/Apache-NMS-AMQP-Test/Message/Facade/NmsTestMessageFacade.cs
+++ b/test/Apache-NMS-AMQP-Test/Message/Facade/NmsTestMessageFacade.cs
@@ -74,7 +74,7 @@ namespace NMS.AMQP.Test.Message.Facade
         public string NMSType { get; set; }
         public string GroupId { get; set; }
         public uint GroupSequence { get; set; }
-        public DateTime Expiration { get; set; }
+        public DateTime? Expiration { get; set; }
         public sbyte JmsMsgType { get; }
         public bool IsPersistent { get; set; }
 

--- a/test/Apache-NMS-AMQP-Test/Provider/Amqp/AmqpNmsMessageFacadeTest.cs
+++ b/test/Apache-NMS-AMQP-Test/Provider/Amqp/AmqpNmsMessageFacadeTest.cs
@@ -1016,11 +1016,11 @@ namespace NMS.AMQP.Test.Provider.Amqp
 
         // --- absolute-expiry-time field  ---
         [Test]
-        public void TestGetExpirationIsZeroForNewMessage()
+        public void TestGetExpirationIsNullForNewMessage()
         {
             AmqpNmsMessageFacade amqpNmsMessageFacade = CreateNewMessageFacade();
 
-            Assert.AreEqual(default(DateTime), amqpNmsMessageFacade.Expiration);
+            Assert.IsNull(amqpNmsMessageFacade.Expiration);
         }
 
         [Test]
@@ -1049,17 +1049,18 @@ namespace NMS.AMQP.Test.Provider.Amqp
         }
 
         [Test]
-        public void TestSetExpirationZeroOnMessageWithExistingExpiryTime()
+        public void TestSetExpirationNullOnMessageWithExistingExpiryTime()
         {
             DateTime timestamp = DateTime.UtcNow;
 
             AmqpNmsMessageFacade amqpNmsMessageFacade = CreateNewMessageFacade();
 
             amqpNmsMessageFacade.Expiration = timestamp;
-            amqpNmsMessageFacade.Expiration = default;
+            amqpNmsMessageFacade.Expiration = null;
 
             Assert.AreEqual(default(DateTime), amqpNmsMessageFacade.Message.Properties.AbsoluteExpiryTime, "Expected absolute-expiry-time to be default");
-            Assert.AreEqual(default(DateTime), amqpNmsMessageFacade.Expiration, "Expected no expiration");
+            Assert.IsFalse(amqpNmsMessageFacade.Message.Properties.HasField(8), "Expected absolute-expiry-time is not set");
+            Assert.AreEqual(null, amqpNmsMessageFacade.Expiration, "Expected no expiration");
         }
 
         // --- user-id field  ---
@@ -1352,7 +1353,7 @@ namespace NMS.AMQP.Test.Provider.Amqp
             Assert.AreEqual(source.IsPersistent, copy.IsPersistent);
             Assert.AreEqual(source.UserId, copy.UserId);
             Assert.AreEqual(source.NMSTimeToLive, copy.NMSTimeToLive);
-            Assert.IsTrue(Math.Abs((copy.Expiration - source.Expiration).TotalMilliseconds) < 1);
+            Assert.IsTrue(Math.Abs((copy.Expiration.Value - source.Expiration.Value).TotalMilliseconds) < 1);
             Assert.IsTrue(Math.Abs((copy.NMSTimestamp - source.NMSTimestamp).TotalMilliseconds) < 1);
             Assert.AreEqual(source.Properties.GetString("APP-Prop-1"), copy.Properties.GetString("APP-Prop-1"));
             Assert.AreEqual(source.GetMessageAnnotation("test-annotation"), copy.GetMessageAnnotation("test-annotation"));


### PR DESCRIPTION
This PR removes workaround https://github.com/apache/activemq-nms-amqp/commit/3c154aa7327b31a905b4b0c7d9df514f56b81960.