### PR TITLE
AMQNET-603: AmqpProvider shouldn't signal exception when connection is explicitly closed

### DIFF
--- a/src/NMS.AMQP/Provider/Amqp/AmqpConnection.cs
+++ b/src/NMS.AMQP/Provider/Amqp/AmqpConnection.cs
@@ -71,7 +71,7 @@ namespace Apache.NMS.AMQP.Provider.Amqp
             Address address = UriUtil.ToAddress(remoteUri, Info.username, Info.password);
             this.tsc = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             underlyingConnection = await transport.CreateAsync(address, new AmqpHandler(this)).ConfigureAwait(false);
-            underlyingConnection.AddClosedCallback(Provider.OnInternalClosed);
+            underlyingConnection.AddClosedCallback((sender, error) => Provider.OnConnectionClosed(error));
             
             // Wait for connection to be opened
             await tsc.Task;

--- a/src/NMS.AMQP/Provider/Amqp/AmqpProvider.cs
+++ b/src/NMS.AMQP/Provider/Amqp/AmqpProvider.cs
@@ -56,9 +56,13 @@ namespace Apache.NMS.AMQP.Provider.Amqp
             return connection.Start();
         }
 
-        internal void OnInternalClosed(IAmqpObject sender, Error error)
+        internal void OnConnectionClosed(Error error)
         {
-            Listener?.OnConnectionFailure(ExceptionSupport.GetException(error));
+            bool connectionExplicitlyClosed = error == null;
+            if (!connectionExplicitlyClosed)
+            {
+                Listener?.OnConnectionFailure(ExceptionSupport.GetException(error));
+            }
         }
 
         internal void FireConnectionEstablished()

--- a/test/Apache-NMS-AMQP-Test/Integration/ConnectionIntegrationTest.cs
+++ b/test/Apache-NMS-AMQP-Test/Integration/ConnectionIntegrationTest.cs
@@ -40,6 +40,22 @@ namespace NMS.AMQP.Test.Integration
         }
 
         [Test, Timeout(20_000)]
+        public void TestExplicitConnectionCloseListenerIsNotInvoked()
+        {
+            using (TestAmqpPeer testPeer = new TestAmqpPeer())
+            {
+                ManualResetEvent exceptionFired = new ManualResetEvent(false);
+                IConnection connection = EstablishConnection(testPeer);
+                connection.ExceptionListener += exception => { exceptionFired.Set(); };
+                
+                testPeer.ExpectClose();
+                connection.Close();
+                
+                Assert.IsFalse(exceptionFired.WaitOne(TimeSpan.FromMilliseconds(100)));
+            }
+        }
+        
+        [Test, Timeout(20_000)]
         public void TestCreateAutoAckSession()
         {
             using (TestAmqpPeer testPeer = new TestAmqpPeer())


### PR DESCRIPTION
AmqpProvider shouldn't signal exception when connection is explicitly closed. It may lead to deadlocks when provider is used with Spring SimpleMessageListenerContainer.

This PR addresses this issue. 

@cjwmorgan-sol Could you please take a look at this? It is implemented according to your suggestion. 