### PR TITLE
AMQNET-612: ObjectMessage shouldn't have jms-msg-type set

### DIFF
--- a/src/NMS.AMQP/Message/Facade/INmsMessageFacade.cs
+++ b/src/NMS.AMQP/Message/Facade/INmsMessageFacade.cs
@@ -38,7 +38,7 @@ namespace Apache.NMS.AMQP.Message.Facade
         string GroupId { get; set; }
         uint GroupSequence { get; set; }
         DateTime? Expiration { get; set; }
-        sbyte JmsMsgType { get; }
+        sbyte? JmsMsgType { get; }
         
         /// <summary>
         /// True if this message is tagged as being persistent

--- a/src/NMS.AMQP/Provider/Amqp/Message/AmqpNmsBytesMessageFacade.cs
+++ b/src/NMS.AMQP/Provider/Amqp/Message/AmqpNmsBytesMessageFacade.cs
@@ -33,7 +33,7 @@ namespace Apache.NMS.AMQP.Provider.Amqp.Message
 
         private static readonly Data EMPTY_DATA = new Data { Binary = new byte[0] };
 
-        public override sbyte JmsMsgType => MessageSupport.JMS_TYPE_BYTE;
+        public override sbyte? JmsMsgType => MessageSupport.JMS_TYPE_BYTE;
         public long BodyLength => GetBinaryFromBody().Binary.LongLength;
 
         public BinaryReader GetDataReader()

--- a/src/NMS.AMQP/Provider/Amqp/Message/AmqpNmsMapMessageFacade.cs
+++ b/src/NMS.AMQP/Provider/Amqp/Message/AmqpNmsMapMessageFacade.cs
@@ -29,7 +29,7 @@ namespace Apache.NMS.AMQP.Provider.Amqp.Message
         private AMQPValueMap map;
         public IPrimitiveMap Map => map;
 
-        public override sbyte JmsMsgType => MessageSupport.JMS_TYPE_MAP;
+        public override sbyte? JmsMsgType => MessageSupport.JMS_TYPE_MAP;
 
         protected override void InitializeEmptyBody()
         {

--- a/src/NMS.AMQP/Provider/Amqp/Message/AmqpNmsMessageFacade.cs
+++ b/src/NMS.AMQP/Provider/Amqp/Message/AmqpNmsMessageFacade.cs
@@ -333,7 +333,7 @@ namespace Apache.NMS.AMQP.Provider.Amqp.Message
         }
 
         public MessageAnnotations MessageAnnotations => Message.MessageAnnotations;
-        public virtual sbyte JmsMsgType => MessageSupport.JMS_TYPE_MSG;
+        public virtual sbyte? JmsMsgType => MessageSupport.JMS_TYPE_MSG;
 
         /// <summary>
         /// The annotation value for the JMS Message content type.  For a generic JMS message this

--- a/src/NMS.AMQP/Provider/Amqp/Message/AmqpNmsObjectMessageFacade.cs
+++ b/src/NMS.AMQP/Provider/Amqp/Message/AmqpNmsObjectMessageFacade.cs
@@ -35,7 +35,7 @@ namespace Apache.NMS.AMQP.Provider.Amqp.Message
             set => Delegate.Object = value;
         }
 
-        public override sbyte JmsMsgType => MessageSupport.JMS_TYPE_OBJ;
+        public override sbyte? JmsMsgType => typeDelegate is AmqpTypedObjectDelegate ? (sbyte?) MessageSupport.JMS_TYPE_OBJ : null;
 
         public override void OnSend(TimeSpan producerTtl)
         {

--- a/src/NMS.AMQP/Provider/Amqp/Message/AmqpNmsStreamMessageFacade.cs
+++ b/src/NMS.AMQP/Provider/Amqp/Message/AmqpNmsStreamMessageFacade.cs
@@ -30,7 +30,7 @@ namespace Apache.NMS.AMQP.Provider.Amqp.Message
         private IList list;
         private int position = 0;
         
-        public override sbyte JmsMsgType => MessageSupport.JMS_TYPE_STRM;
+        public override sbyte? JmsMsgType => MessageSupport.JMS_TYPE_STRM;
 
         public object Peek()
         {

--- a/src/NMS.AMQP/Provider/Amqp/Message/AmqpNmsTextMessageFacade.cs
+++ b/src/NMS.AMQP/Provider/Amqp/Message/AmqpNmsTextMessageFacade.cs
@@ -83,7 +83,7 @@ namespace Apache.NMS.AMQP.Provider.Amqp.Message
             }
         }
 
-        public override sbyte JmsMsgType => MessageSupport.JMS_TYPE_TXT;
+        public override sbyte? JmsMsgType => MessageSupport.JMS_TYPE_TXT;
 
         private static string DecodeBinaryBody(byte[] body)
         {

--- a/test/Apache-NMS-AMQP-Test/Message/Facade/NmsTestMessageFacade.cs
+++ b/test/Apache-NMS-AMQP-Test/Message/Facade/NmsTestMessageFacade.cs
@@ -75,7 +75,7 @@ namespace NMS.AMQP.Test.Message.Facade
         public string GroupId { get; set; }
         public uint GroupSequence { get; set; }
         public DateTime? Expiration { get; set; }
-        public sbyte JmsMsgType { get; }
+        public sbyte? JmsMsgType { get; }
         public bool IsPersistent { get; set; }
 
         public INmsMessageFacade Copy()

--- a/test/Apache-NMS-AMQP-Test/Provider/Amqp/AmqpCodecTest.cs
+++ b/test/Apache-NMS-AMQP-Test/Provider/Amqp/AmqpCodecTest.cs
@@ -458,7 +458,6 @@ namespace NMS.AMQP.Test.Provider.Amqp
             DoTestNMSMessageEncodingAddsProperMessageAnnotations(MessageSupport.JMS_TYPE_MAP, null, MessageSupport.JMS_DEST_TYPE_TEMP_QUEUE);
             DoTestNMSMessageEncodingAddsProperMessageAnnotations(MessageSupport.JMS_TYPE_TXT, MessageSupport.JMS_DEST_TYPE_TOPIC, MessageSupport.JMS_DEST_TYPE_TEMP_QUEUE);
             DoTestNMSMessageEncodingAddsProperMessageAnnotations(MessageSupport.JMS_TYPE_STRM, MessageSupport.JMS_DEST_TYPE_QUEUE, MessageSupport.JMS_DEST_TYPE_TEMP_QUEUE);
-            DoTestNMSMessageEncodingAddsProperMessageAnnotations(MessageSupport.JMS_TYPE_OBJ, MessageSupport.JMS_DEST_TYPE_QUEUE, MessageSupport.JMS_DEST_TYPE_TEMP_QUEUE);
         }
 
         private void DoTestNMSMessageEncodingAddsProperMessageAnnotations(sbyte msgType, byte? toType, byte? replyToType)

--- a/test/Apache-NMS-AMQP-Test/Provider/Amqp/AmqpMessageFactoryTest.cs
+++ b/test/Apache-NMS-AMQP-Test/Provider/Amqp/AmqpMessageFactoryTest.cs
@@ -121,7 +121,7 @@ namespace NMS.AMQP.Test.Provider.Amqp
 
             Assert.IsInstanceOf<NmsObjectMessage>(message);
             Assert.IsInstanceOf<AmqpNmsObjectMessageFacade>(facade);
-            Assert.AreEqual(MessageSupport.JMS_TYPE_OBJ, facade.JmsMsgType);
+            Assert.IsNull(facade.JmsMsgType);
 
             Assert.IsNull(((AmqpNmsObjectMessageFacade) facade).Body);
         }
@@ -137,7 +137,7 @@ namespace NMS.AMQP.Test.Provider.Amqp
 
             Assert.IsInstanceOf<NmsObjectMessage>(message);
             Assert.IsInstanceOf<AmqpNmsObjectMessageFacade>(facade);
-            Assert.AreEqual(MessageSupport.JMS_TYPE_OBJ, facade.JmsMsgType);
+            Assert.IsNull(facade.JmsMsgType);
 
             AmqpNmsObjectMessageFacade objectMessageFacade = (AmqpNmsObjectMessageFacade) facade;
 

--- a/test/Apache-NMS-AMQP-Test/Provider/Amqp/AmqpNmsObjectMessageFacadeTest.cs
+++ b/test/Apache-NMS-AMQP-Test/Provider/Amqp/AmqpNmsObjectMessageFacadeTest.cs
@@ -39,7 +39,7 @@ namespace NMS.AMQP.Test.Provider.Amqp
             AmqpNmsObjectMessageFacade amqpObjectMessageFacade = CreateNewObjectMessageFacade(false);
             Assert.Null(amqpObjectMessageFacade.MessageAnnotations);
 
-            Assert.AreEqual(MessageSupport.JMS_TYPE_OBJ, amqpObjectMessageFacade.JmsMsgType);
+            Assert.IsNull(amqpObjectMessageFacade.JmsMsgType);
         }
 
         [Test]


### PR DESCRIPTION
It addresses https://issues.apache.org/jira/browse/AMQNET-612

I tested it with qpid-jms and it seems to work fine, when .net is a producer and java is a consumer. There is a problem however when the roles change. We still try to interpret object "x-opt-jms-msg-type" for the sake of AmqpTypedObjects but when we receive java serialized payload it breaks. Should we resign from x-opt-jms-msg-type object whatsoever? 