### PR TITLE
AMQNET-620: Initialize ConnectionFactory properly with System.Uri overload

### DIFF
--- a/src/NMS.AMQP/NmsConnectionFactory.cs
+++ b/src/NMS.AMQP/NmsConnectionFactory.cs
@@ -58,7 +58,7 @@ namespace Apache.NMS.AMQP
 
         public NmsConnectionFactory(Uri brokerUri)
         {
-            this.brokerUri = brokerUri;
+            BrokerUri = brokerUri;
         }
 
         private IdGenerator ClientIdGenerator

--- a/test/Apache-NMS-AMQP-Test/ConnectionFactoryTest.cs
+++ b/test/Apache-NMS-AMQP-Test/ConnectionFactoryTest.cs
@@ -66,10 +66,10 @@ namespace NMS.AMQP.Test
         }
 
         [Test]
-        public void TestSetPropertiesFromUri()
+        public void TestSetPropertiesFromStringUri()
         {
             string baseUri = "amqp://localhost:1234";
-            string configured = baseUri +
+            string configuredUri = baseUri +
                                 "?nms.username=user" +
                                 "&nms.password=password" +
                                 "&nms.clientId=client" +
@@ -79,7 +79,33 @@ namespace NMS.AMQP.Test
                                 "&nms.sendTimeout=1000" +
                                 "&nms.localMessageExpiry=false";
 
-            NmsConnectionFactory factory = new NmsConnectionFactory(configured);
+            NmsConnectionFactory factory = new NmsConnectionFactory(configuredUri);
+
+            Assert.AreEqual("user", factory.UserName);
+            Assert.AreEqual("password", factory.Password);
+            Assert.AreEqual("client", factory.ClientId);
+            Assert.AreEqual("ID:TEST", factory.ConnectionIdPrefix);
+            Assert.AreEqual("clientId", factory.ClientIdPrefix);
+            Assert.AreEqual(1000, factory.RequestTimeout);
+            Assert.AreEqual(1000, factory.SendTimeout);
+            Assert.IsFalse(factory.LocalMessageExpiry);
+        }
+        
+        [Test]
+        public void TestSetPropertiesFromUri()
+        {
+            string baseUri = "amqp://localhost:1234";
+            string configuredUri = baseUri +
+                                "?nms.username=user" +
+                                "&nms.password=password" +
+                                "&nms.clientId=client" +
+                                "&nms.connectionIdPrefix=ID:TEST" +
+                                "&nms.clientIDPrefix=clientId" +
+                                "&nms.requestTimeout=1000" +
+                                "&nms.sendTimeout=1000" +
+                                "&nms.localMessageExpiry=false";
+
+            NmsConnectionFactory factory = new NmsConnectionFactory(new Uri(configuredUri));
 
             Assert.AreEqual("user", factory.UserName);
             Assert.AreEqual("password", factory.Password);


### PR DESCRIPTION
ConnectionFactory was not initialized properly with constructor that takes System.Uri as a parameter. Additional properties that were specified in broker uri (like username or password) were not applied on connection factory.