### PR TITLE
AMQNET-634: Use 4 as default msg priority

### DIFF
--- a/src/NMS.AMQP/NmsMessageProducer.cs
+++ b/src/NMS.AMQP/NmsMessageProducer.cs
@@ -34,7 +34,7 @@ namespace Apache.NMS.AMQP
         private MsgDeliveryMode deliveryMode = MsgDeliveryMode.Persistent;
         private TimeSpan timeToLive = NMSConstants.defaultTimeToLive;
         private TimeSpan requestTimeout;
-        private MsgPriority priority = NMSConstants.defaultPriority;
+        private MsgPriority priority = NMSConstants.defaultPriority - 1;
         private bool disableMessageId;
         private bool disableMessageTimestamp;
 

--- a/test/Apache-NMS-AMQP-Test/NmsMessageProducerTest.cs
+++ b/test/Apache-NMS-AMQP-Test/NmsMessageProducerTest.cs
@@ -77,7 +77,7 @@ namespace NMS.AMQP.Test
         public void TestPriorityConfiguration()
         {
             IMessageProducer producer = session.CreateProducer(null);
-            Assert.AreEqual(NMSConstants.defaultPriority, producer.Priority);
+            Assert.AreEqual(MsgPriority.BelowNormal, producer.Priority);
             producer.Priority = MsgPriority.Highest;
             Assert.AreEqual(MsgPriority.Highest, producer.Priority);
         }


### PR DESCRIPTION
This closes https://issues.apache.org/jira/browse/AMQNET-634. 