### PR TITLE
AMQNET-635: Update AMQPNetLite.Core to 2.4.0 version

### DIFF
--- a/src/NMS.AMQP/Apache-NMS-AMQP.csproj
+++ b/src/NMS.AMQP/Apache-NMS-AMQP.csproj
@@ -80,7 +80,7 @@ with the License.  You may obtain a copy of the License at
 
     <ItemGroup>
         <!-- AMQPNetLite.Core is .NET Standard 1.3 package -->
-        <PackageReference Include="AMQPNetLite.Core" Version="2.3.0" />
+        <PackageReference Include="AMQPNetLite.Core" Version="2.4.0" />
         <PackageReference Include="Apache.NMS" Version="1.8.0" />
         <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.9.0" />
     </ItemGroup>


### PR DESCRIPTION
Previous version of AmqpNetLite doesn't support TcpKeepAliveSettings on Linux.