### PR TITLE
AMQNET-639 Add SourceLink support

### DIFF
--- a/package.ps1
+++ b/package.ps1
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 $pkgname = "Apache.NMS.AMQP"
-$pkgver = "1.8.0"
+$pkgver = "1.8.2"
 $frameworks = "netstandard2.0"
 
 write-progress "Creating package directory." "Initializing..."
@@ -34,7 +34,7 @@ if (test-path build) {
     write-progress "Packaging Application files." "Scanning..."
     $zipfile = "$pkgdir\$pkgname-$pkgver-bin.zip"
 
-    Compress-Archive -Path ..\LICENSE.txt, ..\NOTICE.txt -Update -DestinationPath $zipfile        
+    Compress-Archive -Path ..\LICENSE.txt, ..\NOTICE.txt -Update -DestinationPath $zipfile
     
     # clean up temp
     Remove-Item temp -Recurse -ErrorAction Ignore
@@ -47,6 +47,10 @@ if (test-path build) {
     $nupkg = "$pkgname.$pkgver.nupkg"
     $nupkgdestination = "$pkgdir\$nupkg"
     Copy-Item -Path $nupkg -Destination $nupkgdestination
+
+    $snupkg = "$pkgname.$pkgver.snupkg"
+    $snupkgdestination = "$pkgdir\$snupkg"
+    Copy-Item -Path $snupkg -Destination $snupkgdestination
 
     # clean up temp
     Remove-Item temp -Recurse -ErrorAction Inquire

--- a/src/NMS.AMQP/Apache-NMS-AMQP.csproj
+++ b/src/NMS.AMQP/Apache-NMS-AMQP.csproj
@@ -33,7 +33,7 @@ with the License.  You may obtain a copy of the License at
     <PropertyGroup>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageId>Apache.NMS.AMQP</PackageId>
-        <Version>1.8.1</Version>
+        <Version>1.8.2</Version>
         <Authors>Apache ActiveMQ</Authors>
         <Company>Apache Software Foundation</Company>
         <Product>Apache ActiveMQ NMS AMQP Client</Product>
@@ -47,6 +47,20 @@ with the License.  You may obtain a copy of the License at
         <PackageTags>apache;activemq;nms;amqp;net;messaging</PackageTags>
         <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     </PropertyGroup>
+
+    <!-- SourceLink Start -->
+    <PropertyGroup>
+        <!-- Embed source files that are not tracked by the source control manager in the PDB -->
+        <EmbedUntrackedSources>true</EmbedUntrackedSources>
+        <!-- Build symbol package (.snupkg) to distribute the PDB containing Source Link -->
+        <IncludeSymbols>true</IncludeSymbols>
+        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    </PropertyGroup>
+    <ItemGroup>
+        <!-- Add PackageReference specific for your source control provider (see below) -->
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+    </ItemGroup>
+    <!-- SourceLink End -->
 
     <ItemGroup>
         <None Include="..\..\LICENSE.txt" Pack="true" PackagePath="LICENSE.txt" />


### PR DESCRIPTION
I'd like to add SourceLink support to this library in order to simplify debugging from referencing projects.
It would be great to first merge [AMQNET-638 Add SourceLink support](https://github.com/apache/activemq-nms-api/pull/13) and then update [Apache.NMS](https://github.com/apache/activemq-nms-amqp/blob/f1b1f67e1d15b714d7a7c2c827ceeac9978b7a33/src/NMS.AMQP/Apache-NMS-AMQP.csproj#L84) package reference to v.1.8.1

Please take a look into the small demo of SourceLink in action 

![V8RdKuwjuC](https://user-images.githubusercontent.com/290543/78511746-c06f8800-77a7-11ea-89bc-20811a34268c.gif)

For more details on how to enable debugging with SourceLink please check the following guides:

- [How to Configure Visual Studio to Use SourceLink to Step into NuGet Package Source](http://www.aaronstannard.com/visual-studio-sourcelink-setup/)
- [Debugging into NuGet packages with SourceLink in Visual Studio for Mac](https://docs.microsoft.com/en-us/visualstudio/mac/source-link?view=vsmac-2019)


For more details on SoureLink, please navigate the following links:

- [dotnet/sourcelink](https://github.com/dotnet/sourcelink)
- [SourceLink file specification](https://github.com/dotnet/designs/blob/master/accepted/2020/diagnostics/source-link.md#source-link-file-specification)