### PR TITLE
AMQNET-656 failover stalls without reconnecting in some cases - ensure an await statement is not inside a lock statement

### DIFF
--- a/src/NMS.AMQP/Apache-NMS-AMQP.csproj
+++ b/src/NMS.AMQP/Apache-NMS-AMQP.csproj
@@ -94,7 +94,7 @@ with the License.  You may obtain a copy of the License at
 
     <ItemGroup>
         <!-- AMQPNetLite.Core is .NET Standard 1.3 package -->
-        <PackageReference Include="AMQPNetLite.Core" Version="2.4.1" />
+        <PackageReference Include="AMQPNetLite.Core" Version="2.4.3" />
         <PackageReference Include="Apache.NMS" Version="2.0.0" />
         <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.9.0" />
     </ItemGroup>

--- a/src/NMS.AMQP/Provider/Failover/FailoverProvider.cs
+++ b/src/NMS.AMQP/Provider/Failover/FailoverProvider.cs
@@ -103,7 +103,9 @@ namespace Apache.NMS.AMQP.Provider.Failover
             if (closed)
                 return Task.CompletedTask;
 
-            return reconnectControl.ScheduleReconnect(Reconnect);
+            // run on thread pool to ensure that the await statements in ScheduleReconnect are
+            // not inside the lock statements in HandleProviderError and CreateNmsConnection
+            return Task.Run(async () => await reconnectControl.ScheduleReconnect(Reconnect));
 
             async Task Reconnect()
             {

--- a/src/NMS.AMQP/Provider/Failover/FailoverProvider.cs
+++ b/src/NMS.AMQP/Provider/Failover/FailoverProvider.cs
@@ -106,7 +106,7 @@ namespace Apache.NMS.AMQP.Provider.Failover
 
             // run on thread pool to ensure that the await statements in ScheduleReconnect are
             // not inside the lock statements in HandleProviderError and CreateNmsConnection
-            return Task.Run(() => reconnectControl.ScheduleReconnect(Reconnect));
+            return reconnectControl.ScheduleReconnect(Reconnect);
 
             async Task Reconnect()
             {

--- a/src/NMS.AMQP/Provider/Failover/FailoverProvider.cs
+++ b/src/NMS.AMQP/Provider/Failover/FailoverProvider.cs
@@ -105,7 +105,7 @@ namespace Apache.NMS.AMQP.Provider.Failover
 
             // run on thread pool to ensure that the await statements in ScheduleReconnect are
             // not inside the lock statements in HandleProviderError and CreateNmsConnection
-            return Task.Run(async () => await reconnectControl.ScheduleReconnect(Reconnect));
+            return Task.Run(() => reconnectControl.ScheduleReconnect(Reconnect));
 
             async Task Reconnect()
             {

--- a/test/Apache-NMS-AMQP-Test/TestAmqp/TestAmqpPeer.cs
+++ b/test/Apache-NMS-AMQP-Test/TestAmqp/TestAmqpPeer.cs
@@ -71,6 +71,12 @@ namespace NMS.AMQP.Test.TestAmqp
             Open();
         }
 
+        public TestAmqpPeer(int explicitPort)
+        {
+            testAmqpPeerRunner = new TestAmqpPeerRunner(this, new IPEndPoint(IPAddress.Any, explicitPort));
+            Open();
+        }
+
         public int ServerPort => testAmqpPeerRunner.Port;
         public Socket ClientSocket => testAmqpPeerRunner?.ClientSocket;
 


### PR DESCRIPTION
This is in followup to #45. It appears that the Task.Run that was removed from the PR may have been needed after all. At least, I have seen failover fail to reconnect occasionally in our environment, and it appears to be related to this.

I can't offer a full repro to illustrate the issue was present and its resolution, as it is very timing dependent. However, errors are to be expected when an await statement is inside a lock statement.

See also AMQNET-656, opened for this issue, and related cases AMQNET-624 and AMQNET-626, both closed.