### PR TITLE
NO-JIRA: Switch .NET Core targets from 2.2 (no longer supported) back to 2.1 (LTS)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: csharp
 solution: apache-nms-amqp.sln
 mono: none
-dotnet: 2.2.401
+dotnet: 2.1.25
 script:
- - dotnet build -p:AppTargetFramework=netcoreapp2.2 -c Release
- - dotnet test ./test/Apache-NMS-AMQP-Test/Apache-NMS-AMQP-Test.csproj -f netcoreapp2.2 -c Release --filter Category!=Windows
+ - dotnet build -p:AppTargetFramework=netcoreapp2.1 -c Release
+ - dotnet test ./test/Apache-NMS-AMQP-Test/Apache-NMS-AMQP-Test.csproj -f netcoreapp2.1 -c Release --filter Category!=Windows

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: csharp
 solution: apache-nms-amqp.sln
 mono: none
-dotnet: 2.1.25
+dotnet: 2.1.202
 script:
  - dotnet build -p:AppTargetFramework=netcoreapp2.1 -c Release
  - dotnet test ./test/Apache-NMS-AMQP-Test/Apache-NMS-AMQP-Test.csproj -f netcoreapp2.1 -c Release --filter Category!=Windows

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: csharp
 solution: apache-nms-amqp.sln
 mono: none
-dotnet: 2.1.202
+dotnet: 2.1
 script:
  - dotnet build -p:AppTargetFramework=netcoreapp2.1 -c Release
  - dotnet test ./test/Apache-NMS-AMQP-Test/Apache-NMS-AMQP-Test.csproj -f netcoreapp2.1 -c Release --filter Category!=Windows

--- a/src/HelloWorld/HelloWorld.csproj
+++ b/src/HelloWorld/HelloWorld.csproj
@@ -17,7 +17,7 @@ under the License.
 -->
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net462;netcoreapp2.2</TargetFrameworks>
+    <TargetFrameworks>net462;netcoreapp2.1</TargetFrameworks>
     <TargetFramework Condition="'$(AppTargetFramework)' != ''">$(AppTargetFramework)</TargetFramework>
     <OutputType>Exe</OutputType>
     <RootNamespace>HelloWorld</RootNamespace>

--- a/src/PingPong/PingPong.csproj
+++ b/src/PingPong/PingPong.csproj
@@ -18,7 +18,7 @@ with the License.  You may obtain a copy of the License at
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/StructuredMessage/StructuredMessage.csproj
+++ b/src/StructuredMessage/StructuredMessage.csproj
@@ -17,7 +17,7 @@ under the License.
 -->
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net462;netcoreapp2.2</TargetFrameworks>
+    <TargetFrameworks>net462;netcoreapp2.1</TargetFrameworks>
     <TargetFramework Condition="'$(AppTargetFramework)' != ''">$(AppTargetFramework)</TargetFramework>
     <OutputType>Exe</OutputType>
     <RootNamespace>StructuredMessage</RootNamespace>

--- a/src/Transactions/Transactions.csproj
+++ b/src/Transactions/Transactions.csproj
@@ -18,7 +18,7 @@ under the License.
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp2.2</TargetFramework>
+        <TargetFramework>netcoreapp2.1</TargetFramework>
         <TargetFramework Condition="'$(AppTargetFramework)' != ''">$(AppTargetFramework)</TargetFramework>
     </PropertyGroup>
 

--- a/test/Apache-NMS-AMQP-Interop-Test/Apache-NMS-AMQP-Interop-Test.csproj
+++ b/test/Apache-NMS-AMQP-Interop-Test/Apache-NMS-AMQP-Interop-Test.csproj
@@ -16,7 +16,7 @@ under the License.
 -->
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net462;netcoreapp2.2</TargetFrameworks>
+    <TargetFrameworks>net462;netcoreapp2.1</TargetFrameworks>
     <TargetFramework Condition="'$(AppTargetFramework)' != ''">$(AppTargetFramework)</TargetFramework>
     <RootNamespace>NMS.AMQP.Test</RootNamespace>
     <AssemblyName>NMS.AMQP.Interop.Test</AssemblyName>

--- a/test/Apache-NMS-AMQP-Test/Apache-NMS-AMQP-Test.csproj
+++ b/test/Apache-NMS-AMQP-Test/Apache-NMS-AMQP-Test.csproj
@@ -16,7 +16,7 @@ under the License.
 -->
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net462;netcoreapp2.2</TargetFrameworks>
+    <TargetFrameworks>net462;netcoreapp2.1</TargetFrameworks>
     <TargetFramework Condition="'$(AppTargetFramework)' != ''">$(AppTargetFramework)</TargetFramework>
     <RootNamespace>NMS.AMQP.Test</RootNamespace>
     <AssemblyName>NMS.AMQP.Test</AssemblyName>


### PR DESCRIPTION
_This pull request is not necessarily proposed to merge, but is more for discussion - and also for a test to see what Travis CI does with it._

As .NET Core 2.2 has reached end of life, I tried switching the references back to 2.1 which is still supported at this time (albeit only until August). This affects the test suite, the samples, and the CI config. The main output package, targeting .NET Standard 2.0, is unchanged. As far as I can tell, it didn't cause any problems building and testing locally.

It is noted that this PR is mutually exclusive with #49 which contemplates upgrading to .NET Core 3.0; but that 3.0 is also EOL. I would be happy with bumping that to 3.1, and seeing that merged in lieu of this PR - I don't usually target 2.1 anymore myself. However, there was discussion in that PR about preserving compatibility. So, while the present PR it does not take advantage of any new functionality in later versions of .NET, it does continue to test for backward compatibility, at least.
