### PR TITLE
Implement redelivery policy.

### DIFF
--- a/src/NMS.AMQP/NmsConnection.cs
+++ b/src/NMS.AMQP/NmsConnection.cs
@@ -250,7 +250,7 @@ namespace Apache.NMS.AMQP
             }
         }
 
-        public IRedeliveryPolicy RedeliveryPolicy { get; set; } = new DefaultRedeliveryPolicy();
+        public IRedeliveryPolicy RedeliveryPolicy { get; set; }
         public IConnectionMetaData MetaData { get; } = ConnectionMetaData.Version;
         public event ExceptionListener ExceptionListener;
         public event ConnectionInterruptedListener ConnectionInterruptedListener;

--- a/src/NMS.AMQP/NmsConnection.cs
+++ b/src/NMS.AMQP/NmsConnection.cs
@@ -23,6 +23,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Apache.NMS.AMQP.Message;
 using Apache.NMS.AMQP.Meta;
+using Apache.NMS.AMQP.Policies;
 using Apache.NMS.AMQP.Provider;
 using Apache.NMS.AMQP.Util;
 using Apache.NMS.AMQP.Util.Synchronization;
@@ -249,7 +250,7 @@ namespace Apache.NMS.AMQP
             }
         }
 
-        public IRedeliveryPolicy RedeliveryPolicy { get; set; }
+        public IRedeliveryPolicy RedeliveryPolicy { get; set; } = new DefaultRedeliveryPolicy();
         public IConnectionMetaData MetaData { get; } = ConnectionMetaData.Version;
         public event ExceptionListener ExceptionListener;
         public event ConnectionInterruptedListener ConnectionInterruptedListener;

--- a/src/NMS.AMQP/NmsMessageConsumer.cs
+++ b/src/NMS.AMQP/NmsMessageConsumer.cs
@@ -458,14 +458,15 @@ namespace Apache.NMS.AMQP
             return false;
         }
         
-        private int RedeliveryDelay(InboundMessageDispatch envelope)
+        private int GetRedeliveryDelay(InboundMessageDispatch envelope)
         {
             Tracer.DebugFormat("Checking if envelope is redelivered");
             IRedeliveryPolicy redeliveryPolicy = Session.Connection.RedeliveryPolicy;
-            if (redeliveryPolicy == null || envelope.RedeliveryCount <= 0) return 0;
+            
+            if (redeliveryPolicy == null || envelope.RedeliveryCount <= 0) 
+                return 0;
             
             var redeliveryDelay = redeliveryPolicy.RedeliveryDelay(envelope.RedeliveryCount);
-            Tracer.DebugFormat("Envelope has been redelivered, apply redelivery policy wait {0} milliseconds", redeliveryDelay);
             return redeliveryDelay;
         }
 
@@ -583,10 +584,11 @@ namespace Apache.NMS.AMQP
 
         private async Task ApplyRedeliveryPolicy(InboundMessageDispatch envelope)
         {
-            int redeliveryDelay = RedeliveryDelay(envelope);
+            int redeliveryDelay = GetRedeliveryDelay(envelope);
 
             if (redeliveryDelay > 0)
             {
+                Tracer.DebugFormat("Envelope has been redelivered, apply redelivery policy wait {0} milliseconds", redeliveryDelay);
                 await Task.Delay(TimeSpan.FromMilliseconds(redeliveryDelay)).Await();
             }
         }

--- a/src/NMS.AMQP/NmsMessageConsumer.cs
+++ b/src/NMS.AMQP/NmsMessageConsumer.cs
@@ -651,8 +651,17 @@ namespace Apache.NMS.AMQP
             {
                 Tracer.DebugFormat("{0} filtered message with excessive redelivery count: {1}", Info.Id, envelope.RedeliveryCount);
             }
-            var dispositionType = Session.Connection.RedeliveryPolicy.GetOutcome(envelope.Message.NMSDestination);
-            var ackType = LookupAckTypeForDisposition(dispositionType);
+
+            AckType ackType;
+            if (Session.Connection.RedeliveryPolicy is { } redeliveryPolicy)
+            {
+                var dispositionType = redeliveryPolicy.GetOutcome(envelope.Message.NMSDestination);
+                ackType = LookupAckTypeForDisposition(dispositionType);
+            }
+            else
+            {
+                ackType = AckType.MODIFIED_FAILED_UNDELIVERABLE;
+            }
             return Session.AcknowledgeAsync(ackType, envelope);
         }
 

--- a/src/NMS.AMQP/Provider/Amqp/AmqpConsumer.cs
+++ b/src/NMS.AMQP/Provider/Amqp/AmqpConsumer.cs
@@ -340,10 +340,6 @@ namespace Apache.NMS.AMQP.Provider.Amqp
                         receiverLink.Reject(message);
                         RemoveMessage(envelope);
                         break;
-                    case AckType.REJECTED:
-                        receiverLink.Reject(message);
-                        RemoveMessage(envelope);
-                        break;
                     default:
                         Tracer.ErrorFormat("Unsupported Ack Type for message: {0}", envelope);
                         throw new ArgumentException($"Unsupported Ack Type for message: {envelope}");

--- a/src/NMS.AMQP/Provider/Amqp/AmqpConsumer.cs
+++ b/src/NMS.AMQP/Provider/Amqp/AmqpConsumer.cs
@@ -340,6 +340,10 @@ namespace Apache.NMS.AMQP.Provider.Amqp
                         receiverLink.Reject(message);
                         RemoveMessage(envelope);
                         break;
+                    case AckType.REJECTED:
+                        receiverLink.Reject(message);
+                        RemoveMessage(envelope);
+                        break;
                     default:
                         Tracer.ErrorFormat("Unsupported Ack Type for message: {0}", envelope);
                         throw new ArgumentException($"Unsupported Ack Type for message: {envelope}");

--- a/test/Apache-NMS-AMQP-Test/Integration/MessageRedeliveryPolicyIntegrationTest.cs
+++ b/test/Apache-NMS-AMQP-Test/Integration/MessageRedeliveryPolicyIntegrationTest.cs
@@ -47,7 +47,7 @@ namespace NMS.AMQP.Test.Integration
 
                 testPeer.ExpectReceiverAttach();
                 testPeer.ExpectLinkFlowRespondWithTransfer(message: new Amqp.Message() { BodySection = new AmqpValue() { Value = "hello" } });
-                testPeer.ExpectDispositionThatIsRejectedAndSettled();
+                testPeer.ExpectDispositionThatIsModifiedFailedAndSettled();
 
                 IMessageConsumer consumer = session.CreateConsumer(queue);
 
@@ -92,7 +92,7 @@ namespace NMS.AMQP.Test.Integration
                 
                 testPeer.ExpectReceiverAttach();
                 testPeer.ExpectLinkFlowRespondWithTransfer(message: new Amqp.Message() { BodySection = new AmqpValue() { Value = "hello" } });
-                testPeer.ExpectDispositionThatIsRejectedAndSettled();
+                testPeer.ExpectDispositionThatIsModifiedFailedAndSettled();
 
                 IMessageConsumer consumer = session.CreateConsumer(queue);
 

--- a/test/Apache-NMS-AMQP-Test/Integration/MessageRedeliveryPolicyIntegrationTest.cs
+++ b/test/Apache-NMS-AMQP-Test/Integration/MessageRedeliveryPolicyIntegrationTest.cs
@@ -103,7 +103,7 @@ namespace NMS.AMQP.Test.Integration
                         success.Signal();
                 };
                 
-                Assert.IsTrue(success.Wait(TimeSpan.FromSeconds(5)), "Didn't get expected messages");
+                Assert.IsTrue(success.Wait(TimeSpan.FromSeconds(3)), "Didn't get expected messages");
                 
                 testPeer.ExpectClose();
                 connection.Close();

--- a/test/Apache-NMS-AMQP-Test/Integration/MessageRedeliveryPolicyIntegrationTest.cs
+++ b/test/Apache-NMS-AMQP-Test/Integration/MessageRedeliveryPolicyIntegrationTest.cs
@@ -19,6 +19,7 @@ using System;
 using System.Threading;
 using Amqp.Framing;
 using Apache.NMS;
+using Apache.NMS.AMQP.Policies;
 using Apache.NMS.Policies;
 using NMS.AMQP.Test.TestAmqp;
 using NUnit.Framework;
@@ -36,7 +37,7 @@ namespace NMS.AMQP.Test.Integration
                 IConnection connection = EstablishConnection(testPeer);
                 int initialRedeliveryDelay = 1000;
                 int clockResolution = 15;
-                connection.RedeliveryPolicy = new RedeliveryPolicy() { MaximumRedeliveries = 1, InitialRedeliveryDelay = initialRedeliveryDelay};
+                connection.RedeliveryPolicy = new DefaultRedeliveryPolicy { MaximumRedeliveries = 1, InitialRedeliveryDelay = initialRedeliveryDelay};
                 connection.Start();
 
                 testPeer.ExpectBegin();
@@ -80,7 +81,7 @@ namespace NMS.AMQP.Test.Integration
             {
                 IConnection connection = EstablishConnection(testPeer);
                 int initialRedeliveryDelay = 1000;
-                connection.RedeliveryPolicy = new RedeliveryPolicy() { MaximumRedeliveries = 1, InitialRedeliveryDelay = initialRedeliveryDelay};
+                connection.RedeliveryPolicy = new DefaultRedeliveryPolicy { MaximumRedeliveries = 1, InitialRedeliveryDelay = initialRedeliveryDelay};
                 connection.Start();
 
                 testPeer.ExpectBegin();

--- a/test/Apache-NMS-AMQP-Test/Integration/MessageRedeliveryPolicyIntegrationTest.cs
+++ b/test/Apache-NMS-AMQP-Test/Integration/MessageRedeliveryPolicyIntegrationTest.cs
@@ -1,0 +1,115 @@
+﻿/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Threading;
+using Amqp.Framing;
+using Apache.NMS;
+using Apache.NMS.Policies;
+using NMS.AMQP.Test.TestAmqp;
+using NUnit.Framework;
+
+namespace NMS.AMQP.Test.Integration
+{
+    [TestFixture]
+    public class MessageRedeliveryPolicyIntegrationTest : IntegrationTestFixture
+    {
+        [Test, Timeout(20_000)]
+        public void TestIncomingDeliveryCountExceededMessageGetsRejected()
+        {
+            using (TestAmqpPeer testPeer = new TestAmqpPeer())
+            {
+                IConnection connection = EstablishConnection(testPeer);
+                int initialRedeliveryDelay = 1000;
+                int clockResolution = 15;
+                connection.RedeliveryPolicy = new RedeliveryPolicy() { MaximumRedeliveries = 1, InitialRedeliveryDelay = initialRedeliveryDelay};
+                connection.Start();
+
+                testPeer.ExpectBegin();
+
+                ISession session = connection.CreateSession(AcknowledgementMode.IndividualAcknowledge);
+                IQueue queue = session.GetQueue("myQueue");
+
+                testPeer.ExpectReceiverAttach();
+                testPeer.ExpectLinkFlowRespondWithTransfer(message: new Amqp.Message() { BodySection = new AmqpValue() { Value = "hello" } });
+                testPeer.ExpectDispositionThatIsRejectedAndSettled();
+
+                IMessageConsumer consumer = session.CreateConsumer(queue);
+
+                IMessage m = consumer.Receive(TimeSpan.FromMilliseconds(3000));
+                Assert.NotNull(m, "Message should have been received");
+                Assert.IsInstanceOf<ITextMessage>(m);
+                session.Recover();
+
+                DateTime startTimer = DateTime.UtcNow;
+                m = consumer.Receive(TimeSpan.FromMilliseconds(3000));
+                Assert.That(DateTime.UtcNow.Subtract(startTimer).TotalMilliseconds, Is.GreaterThanOrEqualTo(initialRedeliveryDelay - clockResolution));
+
+                Assert.NotNull(m, "Message should have been received");
+                Assert.IsInstanceOf<ITextMessage>(m);
+                session.Recover();
+                
+                // Verify the message is no longer there. Will drain to be sure there are no messages.
+                Assert.IsNull(consumer.Receive(TimeSpan.FromMilliseconds(10)), "Message should not have been received");
+
+                testPeer.ExpectClose();
+                connection.Close();
+
+                testPeer.WaitForAllMatchersToComplete(3000);
+            }
+        }
+        
+        [Test, Timeout(20_000)]
+        public void TestIncomingDeliveryCountExceededMessageGetsRejectedAsync()
+        {
+            using (TestAmqpPeer testPeer = new TestAmqpPeer())
+            {
+                IConnection connection = EstablishConnection(testPeer);
+                int initialRedeliveryDelay = 1000;
+                connection.RedeliveryPolicy = new RedeliveryPolicy() { MaximumRedeliveries = 1, InitialRedeliveryDelay = initialRedeliveryDelay};
+                connection.Start();
+
+                testPeer.ExpectBegin();
+
+                ISession session = connection.CreateSession(AcknowledgementMode.IndividualAcknowledge);
+                IQueue queue = session.GetQueue("myQueue");
+                
+                
+                testPeer.ExpectReceiverAttach();
+                testPeer.ExpectLinkFlowRespondWithTransfer(message: new Amqp.Message() { BodySection = new AmqpValue() { Value = "hello" } });
+                testPeer.ExpectDispositionThatIsRejectedAndSettled();
+
+                IMessageConsumer consumer = session.CreateConsumer(queue);
+
+                CountdownEvent success = new CountdownEvent(2);
+
+                consumer.Listener += m =>
+                {
+                        session.Recover();
+                        success.Signal();
+                };
+                
+                Assert.IsTrue(success.Wait(TimeSpan.FromSeconds(5)), "Didn't get expected messages");
+                
+                testPeer.ExpectClose();
+                connection.Close();
+                
+                testPeer.WaitForAllMatchersToComplete(3000);
+            }
+        }
+    }
+}

--- a/test/Apache-NMS-AMQP-Test/TestAmqp/TestAmqpPeer.cs
+++ b/test/Apache-NMS-AMQP-Test/TestAmqp/TestAmqpPeer.cs
@@ -727,6 +727,11 @@ namespace NMS.AMQP.Test.TestAmqp
             ExpectDisposition(settled: true, stateMatcher: stateMatcher);
         }
         
+        public void ExpectDispositionThatIsRejectedAndSettled()
+        {
+            ExpectDisposition(settled: true, stateMatcher: Assert.IsInstanceOf<Rejected>);
+        }
+        
         public void ExpectDispositionThatIsModifiedFailedAndSettled()
         {
             Action<DeliveryState> stateMatcher = state => { Assert.AreEqual(state.Descriptor.Code, MessageSupport.MODIFIED_FAILED_INSTANCE.Descriptor.Code); };


### PR DESCRIPTION
When setting a RedeliveryPolicy only the MaximumRedeliveries is honoured, RedeliveryDelay is neither calculated nor applied so retries are immediate rather than backing off. Secondly messages that fail to be processed are marked as MODIFIED_FAILED_UNDELIVERABLE rather than REJECTED, which leaves them on the queue until either they expire or the session is restarted.

This change will apply a RedeliveryDelay on retry and mark messages that exceed MaximumRedeliveries as REJECTED. I have tested this with AMQ Artemis and added unit tests.
