### PR TITLE
AMQNET-831 allow acktype modified_failed

### DIFF
--- a/src/NMS.AMQP/Provider/Amqp/AmqpConsumer.cs
+++ b/src/NMS.AMQP/Provider/Amqp/AmqpConsumer.cs
@@ -331,6 +331,10 @@ namespace Apache.NMS.AMQP.Provider.Amqp
                         receiverLink.Modify(message, true, true);
                         RemoveMessage(envelope);
                         break;
+                    case AckType.MODIFIED_FAILED:
+                        receiverLink.Modify(message,true,false);
+                        RemoveMessage(envelope);
+                        break;
                     default:
                         Tracer.ErrorFormat("Unsupported Ack Type for message: {0}", envelope);
                         throw new ArgumentException($"Unsupported Ack Type for message: {envelope}");

--- a/src/NMS.AMQP/Provider/Amqp/AmqpConsumer.cs
+++ b/src/NMS.AMQP/Provider/Amqp/AmqpConsumer.cs
@@ -332,7 +332,11 @@ namespace Apache.NMS.AMQP.Provider.Amqp
                         RemoveMessage(envelope);
                         break;
                     case AckType.MODIFIED_FAILED:
-                        receiverLink.Modify(message,true,false);
+                        receiverLink.Modify(message, true, false);
+                        RemoveMessage(envelope);
+                        break;
+                    case AckType.REJECTED:
+                        receiverLink.Reject(message);
                         RemoveMessage(envelope);
                         break;
                     default:

--- a/test/Apache-NMS-AMQP-Test/Integration/AmqpAcknowledgmentsIntegrationTest.cs
+++ b/test/Apache-NMS-AMQP-Test/Integration/AmqpAcknowledgmentsIntegrationTest.cs
@@ -323,16 +323,9 @@ namespace NMS.AMQP.Test.Integration
                     messages.Remove(message);
 
                     uint deliveryNumber = (uint) message.Properties.GetInt(TestAmqpPeer.MESSAGE_NUMBER) + 1;
-
-                    if (deliveryNumber == 0)
-                    {
-                        testPeer.ExpectDisposition(settled: true, stateMatcher: dispositionMatcherFailed, firstDeliveryId: deliveryNumber, lastDeliveryId: deliveryNumber);
-                        ((NmsMessage) message).NmsAcknowledgeCallback.AcknowledgementType = AckType.MODIFIED_FAILED_UNDELIVERABLE;
-                    }
-                    else
-                    {
-                        testPeer.ExpectDisposition(settled: true, stateMatcher: dispositionMatcher, firstDeliveryId: deliveryNumber, lastDeliveryId: deliveryNumber);
-                    }
+                    
+                    testPeer.ExpectDisposition(settled: true, stateMatcher: dispositionMatcherFailed, firstDeliveryId: deliveryNumber, lastDeliveryId: deliveryNumber);
+                    ((NmsMessage) message).NmsAcknowledgeCallback.AcknowledgementType = AckType.MODIFIED_FAILED_UNDELIVERABLE;
                     
                     message.Acknowledge();
                     
@@ -394,17 +387,10 @@ namespace NMS.AMQP.Test.Integration
                     messages.Remove(message);
 
                     uint deliveryNumber = (uint) message.Properties.GetInt(TestAmqpPeer.MESSAGE_NUMBER) + 1;
-
-                    if (deliveryNumber == 0)
-                    {
-                        testPeer.ExpectDisposition(settled: true, stateMatcher: dispositionMatcherFailed, firstDeliveryId: deliveryNumber, lastDeliveryId: deliveryNumber);
-                        ((NmsMessage) message).NmsAcknowledgeCallback.AcknowledgementType = AckType.REJECTED;
-                    }
-                    else
-                    {
-                        testPeer.ExpectDisposition(settled: true, stateMatcher: dispositionMatcher, firstDeliveryId: deliveryNumber, lastDeliveryId: deliveryNumber);
-                    }
                     
+                    testPeer.ExpectDisposition(settled: true, stateMatcher: dispositionMatcherFailed, firstDeliveryId: deliveryNumber, lastDeliveryId: deliveryNumber);
+                    ((NmsMessage) message).NmsAcknowledgeCallback.AcknowledgementType = AckType.REJECTED;
+
                     message.Acknowledge();
                     
                     testPeer.WaitForAllMatchersToComplete(3000);
@@ -454,7 +440,6 @@ namespace NMS.AMQP.Test.Integration
                 
                 Assert.True(latch.Wait(TimeSpan.FromMilliseconds(1000)), $"Should receive: {msgCount}, but received: {messages.Count}");
                 
-                Action<DeliveryState> dispositionMatcher = state => { Assert.AreEqual(state.Descriptor.Code, MessageSupport.ACCEPTED_INSTANCE.Descriptor.Code); };
                 Action<DeliveryState> dispositionMatcherFailed = state => { Assert.AreEqual(state.Descriptor.Code, MessageSupport.MODIFIED_INSTANCE.Descriptor.Code); };
                 
                 // Acknowledge the messages in a random order and verify the individual dispositions have expected delivery state.
@@ -465,17 +450,10 @@ namespace NMS.AMQP.Test.Integration
                     messages.Remove(message);
 
                     uint deliveryNumber = (uint) message.Properties.GetInt(TestAmqpPeer.MESSAGE_NUMBER) + 1;
-
-                    if (deliveryNumber == 0)
-                    {
-                        testPeer.ExpectDisposition(settled: true, stateMatcher: dispositionMatcherFailed, firstDeliveryId: deliveryNumber, lastDeliveryId: deliveryNumber);
-                        ((NmsMessage) message).NmsAcknowledgeCallback.AcknowledgementType = AckType.MODIFIED_FAILED;
-                    }
-                    else
-                    {
-                        testPeer.ExpectDisposition(settled: true, stateMatcher: dispositionMatcher, firstDeliveryId: deliveryNumber, lastDeliveryId: deliveryNumber);
-                    }
                     
+                    testPeer.ExpectDisposition(settled: true, stateMatcher: dispositionMatcherFailed, firstDeliveryId: deliveryNumber, lastDeliveryId: deliveryNumber);
+                    ((NmsMessage) message).NmsAcknowledgeCallback.AcknowledgementType = AckType.MODIFIED_FAILED;
+                        
                     message.Acknowledge();
                     
                     testPeer.WaitForAllMatchersToComplete(3000);

--- a/test/Apache-NMS-AMQP-Test/Integration/AmqpAcknowledgmentsIntegrationTest.cs
+++ b/test/Apache-NMS-AMQP-Test/Integration/AmqpAcknowledgmentsIntegrationTest.cs
@@ -312,7 +312,6 @@ namespace NMS.AMQP.Test.Integration
                 
                 Assert.True(latch.Wait(TimeSpan.FromMilliseconds(1000)), $"Should receive: {msgCount}, but received: {messages.Count}");
                 
-                Action<DeliveryState> dispositionMatcher = state => { Assert.AreEqual(state.Descriptor.Code, MessageSupport.ACCEPTED_INSTANCE.Descriptor.Code); };
                 Action<DeliveryState> dispositionMatcherFailed = state => { Assert.AreEqual(state.Descriptor.Code, MessageSupport.MODIFIED_FAILED_INSTANCE.Descriptor.Code); };
                 
                 // Acknowledge the messages in a random order and verify the individual dispositions have expected delivery state.
@@ -376,7 +375,6 @@ namespace NMS.AMQP.Test.Integration
                 
                 Assert.True(latch.Wait(TimeSpan.FromMilliseconds(1000)), $"Should receive: {msgCount}, but received: {messages.Count}");
                 
-                Action<DeliveryState> dispositionMatcher = state => { Assert.AreEqual(state.Descriptor.Code, MessageSupport.ACCEPTED_INSTANCE.Descriptor.Code); };
                 Action<DeliveryState> dispositionMatcherFailed = state => { Assert.AreEqual(state.Descriptor.Code, MessageSupport.REJECTED_INSTANCE.Descriptor.Code); };
                 
                 // Acknowledge the messages in a random order and verify the individual dispositions have expected delivery state.


### PR DESCRIPTION
This pull request adds the ability to acknowledge messages with MODIFIED_FAILED, instead of MODIFIED_FAILED_UNDELIVERABLE. 
A very basic example below:
```csharp
 private void ReceiveMessage(IMessage message)
    {
        var txt = message.Body<string>();

        _logger.LogInformation("message received: {Content}", txt);


        if (txt.Contains('5') && message is NmsMessage msg)
        {
            msg.NmsAcknowledgeCallback.AcknowledgementType = AckType.MODIFIED_FAILED;
        }

        message.Acknowledge();
    }
```

As far as i can see, this method is the only way to acknowledge a failure when using `AcknowledgementMode.IndividualAcknowledge`

I tested this with an artemis broker, and all tests still run fine.