### PR TITLE
AMQNET-606: Ignore can be removed. test works

### DIFF
--- a/test/Apache-NMS-AMQP-Test/Integration/FailoverIntegrationTest.cs
+++ b/test/Apache-NMS-AMQP-Test/Integration/FailoverIntegrationTest.cs
@@ -447,7 +447,7 @@ namespace NMS.AMQP.Test.Integration
             DoFailoverPassthroughOfFailingSyncSendTestImpl(new Released());
         }
 
-        [Test, Timeout(20_000), Ignore("TODO: It should be fixed.")]
+        [Test, Timeout(20_000)]
         public void TestFailoverPassthroughOfModifiedFailedSyncSend()
         {
             var modified = new Modified()


### PR DESCRIPTION
The test referenced in this issue is actually fixed. The ignore attribute can be safely deleted