### PR TITLE
Amqnet 834 add better access to ConsumerDestination

### DIFF
--- a/src/NMS.AMQP/Message/Facade/INmsMessageFacade.cs
+++ b/src/NMS.AMQP/Message/Facade/INmsMessageFacade.cs
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 using System;
 
 namespace Apache.NMS.AMQP.Message.Facade
@@ -29,6 +30,7 @@ namespace Apache.NMS.AMQP.Message.Facade
         IPrimitiveMap Properties { get; }
         string NMSCorrelationID { get; set; }
         IDestination NMSDestination { get; set; }
+        IDestination NMSConsumerDestination { get; set; }
         TimeSpan NMSTimeToLive { get; set; }
         MsgPriority NMSPriority { get; set; }
         bool NMSRedelivered { get; set; }
@@ -40,7 +42,7 @@ namespace Apache.NMS.AMQP.Message.Facade
         uint GroupSequence { get; set; }
         DateTime? Expiration { get; set; }
         sbyte? JmsMsgType { get; }
-        
+
         /// <summary>
         /// True if this message is tagged as being persistent
         /// </summary>

--- a/src/NMS.AMQP/Provider/Amqp/Message/AmqpNmsMessageFacade.cs
+++ b/src/NMS.AMQP/Provider/Amqp/Message/AmqpNmsMessageFacade.cs
@@ -35,7 +35,6 @@ namespace Apache.NMS.AMQP.Provider.Amqp.Message
         private TimeSpan? amqpTimeToLiveOverride;
         private IDestination destination;
         private IDestination replyTo;
-        private IDestination consumerDestination;
         private IAmqpConnection connection;
         private DateTime? syntheticExpiration;
         private DateTime syntheticDeliveryTime;
@@ -133,7 +132,7 @@ namespace Apache.NMS.AMQP.Provider.Amqp.Message
 
         public IDestination NMSDestination
         {
-            get => destination ?? (destination = AmqpDestinationHelper.GetDestination(this, connection, consumerDestination));
+            get => destination ?? (destination = AmqpDestinationHelper.GetDestination(this, connection, NMSConsumerDestination));
             set
             {
                 destination = value;
@@ -149,10 +148,12 @@ namespace Apache.NMS.AMQP.Provider.Amqp.Message
                 }
             }
         }
+        
+        public IDestination NMSConsumerDestination { get; set; }
 
         public IDestination NMSReplyTo
         {
-            get => replyTo ?? (replyTo = AmqpDestinationHelper.GetReplyTo(this, connection, consumerDestination));
+            get => replyTo ?? (replyTo = AmqpDestinationHelper.GetReplyTo(this, connection, NMSConsumerDestination));
             set
             {
                 replyTo = value;
@@ -410,7 +411,7 @@ namespace Apache.NMS.AMQP.Provider.Amqp.Message
         /// </summary>
         public virtual void Initialize(IAmqpConsumer consumer, global::Amqp.Message message)
         {
-            this.consumerDestination = consumer.Destination;
+            this.NMSConsumerDestination = consumer.Destination;
             this.connection = consumer.Connection;
             Message = message;
 
@@ -487,7 +488,7 @@ namespace Apache.NMS.AMQP.Provider.Amqp.Message
         protected void CopyInto(AmqpNmsMessageFacade target)
         {
             target.connection = connection;
-            target.consumerDestination = consumerDestination;
+            target.NMSConsumerDestination = NMSConsumerDestination;
             target.syntheticExpiration = syntheticExpiration;
             target.syntheticDeliveryTime = syntheticDeliveryTime;
             target.amqpTimeToLiveOverride = amqpTimeToLiveOverride;

--- a/test/Apache-NMS-AMQP-Test/Integration/FailoverIntegrationTest.cs
+++ b/test/Apache-NMS-AMQP-Test/Integration/FailoverIntegrationTest.cs
@@ -447,7 +447,7 @@ namespace NMS.AMQP.Test.Integration
             DoFailoverPassthroughOfFailingSyncSendTestImpl(new Released());
         }
 
-        [Test, Timeout(20_000), Ignore("TODO: It should be fixed.")]
+        [Test, Timeout(20_000)]
         public void TestFailoverPassthroughOfModifiedFailedSyncSend()
         {
             var modified = new Modified()

--- a/test/Apache-NMS-AMQP-Test/Message/Facade/NmsTestMessageFacade.cs
+++ b/test/Apache-NMS-AMQP-Test/Message/Facade/NmsTestMessageFacade.cs
@@ -54,6 +54,7 @@ namespace NMS.AMQP.Test.Message.Facade
         public IPrimitiveMap Properties { get; } = new PrimitiveMap();
         public string NMSCorrelationID { get; set; }
         public IDestination NMSDestination { get; set; }
+        public IDestination NMSConsumerDestination { get; set; }
         public TimeSpan NMSTimeToLive { get; set; }
         public MsgPriority NMSPriority { get; set; }
         public bool NMSRedelivered { get; set; }


### PR DESCRIPTION
see: https://issues.apache.org/jira/browse/AMQNET-834

This pull request adds a makes the property "consumerDestination" public. This enables applications to view the fully qualified destination name, when subscribed to a topic, instead of only the topic address.

E.g.
now, when you are subscribed to a topic "topic.my.topic::consumer.topic.my.topic", and you receive a message with nms. When you look at NMSDestination on the message, you'll only see "topic.my.topic"
With this pull request, and possible an extra one to nms-api (for the IMessage type), you can look at NMSConsumerDestination, and you'll see "topic.my.topic::consumer.topic.my.topic".

The only way we can get the fully qualified name now, is trough reflection:
```csharp
var prop = msg.GetType()
                    .GetProperty("consumerDestination", BindingFlags.NonPublic | BindingFlags.Instance);
```
