### PR TITLE
Fix high CPU usage in case AmqpNetLite.Core 2.4.8+

### DIFF
--- a/src/NMS.AMQP/Provider/Amqp/AmqpConnection.cs
+++ b/src/NMS.AMQP/Provider/Amqp/AmqpConnection.cs
@@ -115,7 +115,10 @@ namespace Apache.NMS.AMQP.Provider.Amqp
             open.ChannelMax = Info.ChannelMax;
             open.MaxFrameSize = (uint) Info.MaxFrameSize;
             open.HostName = String.IsNullOrWhiteSpace(this.Provider.VHost) ? remoteUri.Host : this.Provider.VHost;
-            open.IdleTimeOut = (uint) Info.IdleTimeOut;
+            if (Info.IdleTimeOut > 0)
+            {
+                open.IdleTimeOut = (uint)Info.IdleTimeOut;
+            }
             open.DesiredCapabilities = new[]
             {
                 SymbolUtil.OPEN_CAPABILITY_SOLE_CONNECTION_FOR_CONTAINER,

--- a/test/Apache-NMS-AMQP-Test/Provider/Amqp/AmqpConnectionTest.cs
+++ b/test/Apache-NMS-AMQP-Test/Provider/Amqp/AmqpConnectionTest.cs
@@ -1,0 +1,76 @@
+﻿/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using Amqp.Framing;
+using Apache.NMS.AMQP.Meta;
+using Apache.NMS.AMQP.Provider;
+using Apache.NMS.AMQP.Provider.Amqp;
+using NUnit.Framework;
+
+namespace NMS.AMQP.Test.Provider.Amqp
+{
+    [TestFixture]
+    public class AmqpConnectionTest
+    {
+        private AmqpProvider provider;
+        private AmqpConnection connection;
+        private AmqpHandler handler;
+
+        [SetUp]
+        public void Setup()
+        {
+            provider = ProviderFactory.Create(GetDefaultUri()) as AmqpProvider;
+        }
+        
+        [TearDown]
+        public void TearDown()
+        {
+            if (provider != null)
+            {
+                provider.Close();
+                provider = null;
+            }
+        }
+
+        [TestCaseSource(nameof(_timeoutTestCases))]
+        public void TestIdleTimeoutIsPassedOnlyIfNotNegative(int configuredIdleTimeout, uint expectedIdleTimeOut)
+        {
+            var nmsConnectionInfo = new NmsConnectionInfo(new NmsConnectionId("mock"));
+            nmsConnectionInfo.IdleTimeOut = configuredIdleTimeout;
+            connection = new AmqpConnection(provider, null, nmsConnectionInfo);
+            var open = new Open();
+            connection.OnLocalOpen(open);
+            Assert.AreEqual(open.IdleTimeOut, expectedIdleTimeOut);
+        }
+
+        private static object[] _timeoutTestCases =
+        [
+            new object[] { int.MaxValue, 2147483647u },
+            new object[] { int.MinValue, 0u },
+            new object[] { 123, 123u },
+            new object[] { 0, 0u },
+            new object[] { -1, 0u },
+            new object[] { -23, 0u }
+        ];
+        
+        private Uri GetDefaultUri()
+        {
+            return new Uri("amqp://localhost:5672");
+        }
+    }
+}


### PR DESCRIPTION
Since AMQPNetLite [v2.4.8](https://github.com/Azure/amqpnetlite/releases/tag/v2.4.8) the IdleTimeOut supports negative values. 
The new default value is -1.
If the timeout of -1 get casted to uint it becames uint.MaxValue. 
This lead to wrong working heartbeat and **high CPU usage**.

Below a detailled explaination about the issue and how to reproduce it.

## How to reproduce the issue

This issue occurs every time you attempt to use a newer version of the AmqpNetLite.Core. The Nuget package for [ApacheNMS.AMQP](https://www.nuget.org/packages/Apache.NMS.AMQP#dependencies-body-tab) requires AMQPNetLite.Core >= 2.4.3 .
Up to version 2.4.7, there is no meaningful difference in the behavior of the library.
Starting on the version 2.4.8 and newer, I detected an high CPU consumption during idle.

This can be easily reproduced in this way:
1. Create an empty project and reference the AMQPNetLite.Core explicitly. 
  #### example.csproj
  ```
  <Project Sdk="Microsoft.NET.Sdk">
  
      <PropertyGroup>
          <OutputType>Exe</OutputType>
          <TargetFramework>net8.0</TargetFramework>
          <ImplicitUsings>enable</ImplicitUsings>
          <Nullable>enable</Nullable>
      </PropertyGroup>
  
      <ItemGroup>
          <PackageReference Include="AMQPNetLite.Core" Version="2.4.7" />
          <PackageReference Include="Apache.NMS" Version="2.2.0" />
          <PackageReference Include="Apache.NMS.AMQP" Version="2.4.0" />
      </ItemGroup>
  
  </Project>
  ```

  #### Program.cs
  ```csharp
  using Apache.NMS;
  
  var connectionString = new Uri(Environment.GetEnvironmentVariable("ConnectionString")!);
  
  var username = Environment.GetEnvironmentVariable("Username");
  var password = Environment.GetEnvironmentVariable("Password");
  
  var connection = new NMSConnectionFactory(connectionString, Array.Empty<object>())
      .CreateConnection(username, password);
  var session = connection.CreateSession();
  
  connection.Start();
  
  Console.WriteLine("Press enter to exit...");
  Console.ReadLine();
  ```
  
2. Check the Performance differences between AMQPNetLite.Core 2.4.7 and 2.4.8.
  - 2.4.7
  Apart of some initial activity, you see 0% CPU usage  
  <img width="1352" height="350" alt="image" src="https://github.com/user-attachments/assets/1ff36f93-57a3-445f-8b5f-ad40c444d054" />

  - 2.4.8
  The CPU goes high up to 20% while the program is actually be in idle the whole time (no producers neither consumers)
  
  <img width="1376" height="349" alt="image" src="https://github.com/user-attachments/assets/91691369-943c-4439-ba59-02368a652bdc" />
  In a containerized application with low memory and CPU quota grant, it goes even higher.

## How/why this occurs

The apache.nsm.amqp library performs a casting from the default value (if not overriden):
<img width="824" height="359" alt="image" src="https://github.com/user-attachments/assets/14a7b3cd-9104-4a07-980d-5a6c34716e36" />

this lead to an unintended value in case of -1, the new default value fo this setting:
<img width="824" height="331" alt="image" src="https://github.com/user-attachments/assets/f5619de3-69f5-4e61-91c2-a9d90799fb3e" />


## Proposed solution

Since the underlaying library AmqpNetLite.Core changed the default value and its behavior in this matter, I think the apache.nsm.amqp should perfom a casting only if the IdleTimeOut is not negative and pass `0` elsewhere. This will allow to keep a low dependency requirement, remain backward capable and also fit newer version of AMQPNetLite.Core.
