### PR TITLE
Fix NmsMessageConsumer's AsyncListener Event Property

### DIFF
--- a/src/NMS.AMQP/NmsMessageConsumer.cs
+++ b/src/NMS.AMQP/NmsMessageConsumer.cs
@@ -125,7 +125,7 @@ namespace Apache.NMS.AMQP
             }
             remove
             {
-                using (syncRoot.LockAsync())
+                using (syncRoot.Lock())
                 {
                     AsyncListener -= value;
                 }


### PR DESCRIPTION
In the NmsMessageConsumer class, for the AsyncListener event property, change the call to syncRoot.LockAsync() to syncRoot.Lock() to correct the issue where the consumer does not add a handler if the remover is called first.
