### PR TITLE
refactor: change byte to sbyte for message destination types and annotations

### DIFF
--- a/src/NMS.AMQP/Util/AmqpDestinationHelper.cs
+++ b/src/NMS.AMQP/Util/AmqpDestinationHelper.cs
@@ -73,7 +73,7 @@ namespace Apache.NMS.AMQP.Util
             object typeAnnotation = message.GetMessageAnnotation(SymbolUtil.JMSX_OPT_DEST);
             if (typeAnnotation != null)
             {
-                byte type = Convert.ToByte(typeAnnotation);
+                sbyte type = Convert.ToSByte(typeAnnotation);
                 string name = StripPrefixIfNecessary(to, connection, type);
                 return CreateDestination(name, type);
             }
@@ -91,7 +91,7 @@ namespace Apache.NMS.AMQP.Util
             object typeAnnotation = message.GetMessageAnnotation(SymbolUtil.JMSX_OPT_REPLY_TO);
             if (typeAnnotation != null)
             {
-                byte type = Convert.ToByte(typeAnnotation);
+                sbyte type = Convert.ToSByte(typeAnnotation);
                 string name = StripPrefixIfNecessary(replyTo, connection, type);
                 return CreateDestination(name, type);
             }
@@ -102,7 +102,7 @@ namespace Apache.NMS.AMQP.Util
             }
         }
 
-        private static string StripPrefixIfNecessary(string address, IAmqpConnection connection, byte type)
+        private static string StripPrefixIfNecessary(string address, IAmqpConnection connection, sbyte type)
         {
             if (address == null)
                 return null;
@@ -147,7 +147,7 @@ namespace Apache.NMS.AMQP.Util
             return address;
         }
 
-        private static IDestination CreateDestination(string address, byte typeByte)
+        private static IDestination CreateDestination(string address, sbyte typeByte)
         {
             if (address == null)
                 return null;
@@ -224,16 +224,16 @@ namespace Apache.NMS.AMQP.Util
             if (destination.IsQueue)
             {
                 if (destination.IsTemporary)
-                    return (sbyte)MessageSupport.JMS_DEST_TYPE_TEMP_QUEUE;
+                    return MessageSupport.JMS_DEST_TYPE_TEMP_QUEUE;
                 else
-                    return (sbyte)MessageSupport.JMS_DEST_TYPE_QUEUE;
+                    return MessageSupport.JMS_DEST_TYPE_QUEUE;
             }
             else if (destination.IsTopic)
             {
                 if (destination.IsTemporary)
-                    return (sbyte)MessageSupport.JMS_DEST_TYPE_TEMP_TOPIC;
+                    return MessageSupport.JMS_DEST_TYPE_TEMP_TOPIC;
                 else
-                    return (sbyte)MessageSupport.JMS_DEST_TYPE_TOPIC;
+                    return MessageSupport.JMS_DEST_TYPE_TOPIC;
             }
 
             return null;

--- a/src/NMS.AMQP/Util/MessageSupport.cs
+++ b/src/NMS.AMQP/Util/MessageSupport.cs
@@ -42,10 +42,10 @@ namespace Apache.NMS.AMQP.Util
         public const sbyte JMS_TYPE_TXT = 0x05;
 
         // "x-opt-jms-dest" and "x-opt-jms-reply-to" values
-        public const byte JMS_DEST_TYPE_QUEUE = 0x00;
-        public const byte JMS_DEST_TYPE_TOPIC = 0x01;
-        public const byte JMS_DEST_TYPE_TEMP_QUEUE = 0x02;
-        public const byte JMS_DEST_TYPE_TEMP_TOPIC = 0x03;
+        public const sbyte JMS_DEST_TYPE_QUEUE = 0x00;
+        public const sbyte JMS_DEST_TYPE_TOPIC = 0x01;
+        public const sbyte JMS_DEST_TYPE_TEMP_QUEUE = 0x02;
+        public const sbyte JMS_DEST_TYPE_TEMP_TOPIC = 0x03;
 
         // Message Content-type values
         public const string OCTET_STREAM_CONTENT_TYPE = "application/octet-stream";

--- a/test/Apache-NMS-AMQP-Test/Provider/Amqp/AmqpCodecTest.cs
+++ b/test/Apache-NMS-AMQP-Test/Provider/Amqp/AmqpCodecTest.cs
@@ -460,7 +460,7 @@ namespace NMS.AMQP.Test.Provider.Amqp
             DoTestNMSMessageEncodingAddsProperMessageAnnotations(MessageSupport.JMS_TYPE_STRM, MessageSupport.JMS_DEST_TYPE_QUEUE, MessageSupport.JMS_DEST_TYPE_TEMP_QUEUE);
         }
 
-        private void DoTestNMSMessageEncodingAddsProperMessageAnnotations(sbyte msgType, byte? toType, byte? replyToType)
+        private void DoTestNMSMessageEncodingAddsProperMessageAnnotations(sbyte msgType, sbyte? toType, sbyte? replyToType)
         {
             AmqpNmsMessageFacade messageFacade = CreateMessageFacadeFromTypeId(msgType);
             IDestination to = CreateDestinationFromTypeId(toType);
@@ -564,7 +564,7 @@ namespace NMS.AMQP.Test.Provider.Amqp
             return message;
         }
 
-        private IDestination CreateDestinationFromTypeId(byte? destinationType)
+        private IDestination CreateDestinationFromTypeId(sbyte? destinationType)
         {
             switch (destinationType)
             {


### PR DESCRIPTION
It's a follow up for #101. 